### PR TITLE
fix avoid set hover to false when swiping out to top

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -194,11 +194,20 @@
 [data-sonner-toast][data-swiping='true']:before {
   content: '';
   position: absolute;
-  top: 50%;
   left: 0;
   right: 0;
   height: 100%;
+}
+
+[data-sonner-toast][data-y-position='top'][data-swiping='true']:before {
+  /* y 50% needed to distribute height additional height evenly */
+  bottom: 50%;
+  transform: scaleY(3) translateY(50%);
+}
+
+[data-sonner-toast][data-y-position='bottom'][data-swiping='true']:before {
   /* y -50% needed to distribute height additional height evenly */
+  top: 50%;
   transform: scaleY(3) translateY(-50%);
 }
 
@@ -275,7 +284,7 @@
 
 [data-sonner-toast][data-swipe-out='true'][data-y-position='bottom'],
 [data-sonner-toast][data-swipe-out='true'][data-y-position='top'] {
-  animation: swipe-out 200ms ease-out;
+  animation: swipe-out 200ms ease-out forwards;
 }
 
 @keyframes swipe-out {


### PR DESCRIPTION
Avoid setting hover to false when swiping out to top and sometimes I saw a flash when swipe out the toast so I added `forwards` to `swipe-out` animation.

### Before

https://user-images.githubusercontent.com/48808846/221189672-3cff19b6-8cfd-4abf-bd3e-366054fd2576.mp4

### After

https://user-images.githubusercontent.com/48808846/221189731-5302f5ec-3f0e-4142-9565-86533950f1af.mp4

