### PR TITLE
docs(website): match types copy to readme.md

### DIFF
--- a/website/src/components/Types/Types.tsx
+++ b/website/src/components/Types/Types.tsx
@@ -9,7 +9,7 @@ export const Types = () => {
     <div>
       <h2>Types</h2>
       <p>
-        You can add <code>richColors</code> prop to make error and success toasts more colorful
+        You can customize the type of toast you want, or pass an options object as the second argument.
       </p>
       <div className="buttons">
         {allTypes.map((type) => (

--- a/website/src/components/Types/Types.tsx
+++ b/website/src/components/Types/Types.tsx
@@ -9,7 +9,7 @@ export const Types = () => {
     <div>
       <h2>Types</h2>
       <p>
-        You can customize the type of toast you want, or pass an options object as the second argument.
+        You can customize the type of toast you want to render, and pass an options object as the second argument.
       </p>
       <div className="buttons">
         {allTypes.map((type) => (


### PR DESCRIPTION
[<img align=right width="50%" alt="the current Types section" src="https://user-images.githubusercontent.com/886627/221256743-d818db21-14ec-422c-9abc-f85de60e3717.png">][site] The current **Types** section [on the website][site] seems to have the wrong copy… 😬 (It looks like it was copy-and-pasted from the **Rich Colors** section accidentally and never got updated!)

- [x] This PR updates the copy to vaguely [match what's in the main readme][rdme].

[site]: https://sonner.emilkowal.ski
[rdme]: https://github.com/emilkowalski/sonner#types