### PR TITLE
Add ability to add className to description

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Toasts can also be expanded by default through the `expand` prop. You can also c
 You can style your toasts globally with the `toastOptions` prop in the `Toaster` component.
 
 ```jsx
-<Toaster toastOptions={{ style: { background: 'red' }, className: 'my-toast' }} />
+<Toaster toastOptions={{ style: { background: 'red' }, className: 'my-toast', descriptionClassName: 'my-toast-description' }} />
 ```
 
 ### Styling for individual toast
@@ -143,6 +143,7 @@ toast('Event has been created', {
     background: 'red',
   },
   className: 'my-toast',
+  descriptionClassName: 'my-toast-description',
 });
 ```
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,7 @@ interface ToastProps {
   style?: React.CSSProperties;
   duration?: number;
   className?: string;
+  descriptionClassName?: string;
 }
 
 const Toast = (props: ToastProps) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,6 +61,7 @@ const Toast = (props: ToastProps) => {
     closeButton,
     style,
     className = '',
+    descriptionClassName = '',
     duration: durationFromToaster,
     position,
     expandByDefault,
@@ -77,6 +78,8 @@ const Toast = (props: ToastProps) => {
   const isVisible = index + 1 <= visibleToasts;
   const toastType = toast.type;
   const toastClassname = toast.className || '';
+  const toastDescriptionClassname = toast.descriptionClassName || '';
+
   // Height index is used to calculate the offset as it gets updated before the toast array, which means we can calculate the new layout faster.
   const heightIndex = React.useMemo(
     () => heights.findIndex((height) => height.toastId === toast.id) || 0,
@@ -314,7 +317,14 @@ const Toast = (props: ToastProps) => {
 
           <div data-content="">
             <div data-title="">{toast.title ?? promiseTitle}</div>
-            {toast.description ? <div data-description="">{toast.description}</div> : null}
+            {toast.description ? (
+              <div
+                data-description=""
+                className={descriptionClassName + toast.descriptionClassName}
+              >
+                {toast.description}
+              </div>
+              ) : null}
           </div>
           {toast.cancel ? (
             <button

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -320,7 +320,7 @@ const Toast = (props: ToastProps) => {
             {toast.description ? (
               <div
                 data-description=""
-                className={descriptionClassName + toast.descriptionClassName}
+                className={descriptionClassName + toastDescriptionClassname}
               >
                 {toast.description}
               </div>
@@ -359,6 +359,7 @@ const Toast = (props: ToastProps) => {
 
 interface ToastOptions {
   className?: string;
+  descriptionClassName?: string;
   style?: React.CSSProperties;
 }
 
@@ -482,6 +483,7 @@ const Toaster = (props: ToasterProps) => {
             toast={toast}
             duration={duration}
             className={toastOptions?.className}
+            descriptionClassName={toastOptions?.descriptionClassName}
             invert={invert}
             visibleToasts={visibleToasts}
             closeButton={closeButton}

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface ToastT {
   promiseData?: PromiseData;
   style?: React.CSSProperties;
   className?: string;
+  descriptionClassName?: string;
 }
 
 export type Position = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'top-center' | 'bottom-center';


### PR DESCRIPTION
Thanks for your work on this package, I love it!

This PR adds the ability to specify classNames to use for the description. You can either set the descriptionClassName on the `<Toaster/>` component or on individual toasts.

This is super handy for Tailwind users. For example:

```tsx
toast('The thing was successful', {
  description: 'Here\'s some additional info about the thing',
  className: 'font-medium text-gray-800',
  descriptionClassName: 'font-normal text-gray-500'
});
```

or

```tsx
<Toaster toastOptions={{descriptionClassName: 'font-normal text-gray-500'}} />
```
