### PR TITLE
feat(Types): adds warning type toast

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Renders a checkmark icon in front of the message.
 toast.success('Event has been created');
 ```
 
+### Warning
+
+Renders a warning icon in front of the message.
+
+```jsx
+toast.warning('Event did something unexpected');
+```
+
 ### Error
 
 Renders an error icon in front of the message.

--- a/src/assets.tsx
+++ b/src/assets.tsx
@@ -43,11 +43,11 @@ const SuccessIcon = (
 );
 
 const WarningIcon = (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" height="16" width="20">
-    <path
-      fillRule="evenodd"
-      d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
-      clipRule="evenodd"
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" height="20" width="20">
+    <path 
+      fill-rule="evenodd" 
+      d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z" 
+      clip-rule="evenodd"
     />
   </svg>
 );

--- a/src/assets.tsx
+++ b/src/assets.tsx
@@ -10,6 +10,9 @@ export const getAsset = (type: ToastTypes): JSX.Element | null => {
     case 'error':
       return ErrorIcon;
 
+    case 'warning':
+      return WarningIcon;
+
     default:
       null;
   }
@@ -34,6 +37,16 @@ const SuccessIcon = (
     <path
       fillRule="evenodd"
       d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+const WarningIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" height="16" width="20">
+    <path
+      fillRule="evenodd"
+      d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
       clipRule="evenodd"
     />
   </svg>

--- a/src/state.ts
+++ b/src/state.ts
@@ -47,6 +47,12 @@ class Observer {
     return id;
   };
 
+  warning = (message: string | React.ReactNode, data?: ExternalToast) => {
+    const id = toastsCounter++;
+    this.publish({ ...data, id, type: 'warning', title: message });
+    return id;
+  };
+
   promise = (promise: PromiseT, data?: PromiseData) => {
     const id = toastsCounter++;
     this.publish({ ...data, promise, id });
@@ -79,6 +85,7 @@ const basicToast = toastFunction;
 export const toast = Object.assign(basicToast, {
   success: ToastState.success,
   error: ToastState.error,
+  warning: ToastState.warning,
   custom: ToastState.custom,
   message: ToastState.message,
   promise: ToastState.promise,

--- a/src/styles.css
+++ b/src/styles.css
@@ -353,6 +353,10 @@
   --error-bg: hsl(359, 100%, 97%);
   --error-border: hsl(359, 100%, 94%);
   --error-text: hsl(360, 100%, 45%);
+
+  --warning-bg: hsl(24, 100%, 97%);
+  --warning-border: hsl(29, 100%, 94%);
+  --warning-text: hsl(26, 100%, 45%);
 }
 
 [data-sonner-toaster][data-theme='light'] [data-sonner-toast][data-invert='true'] {
@@ -379,6 +383,10 @@
   --error-bg: hsl(358, 76%, 10%);
   --error-border: hsl(357, 89%, 16%);
   --error-text: hsl(358, 100%, 81%);
+
+  --warning-bg: hsl(28, 76%, 10%);
+  --warning-border: hsl(24, 90%, 16%);
+  --warning-text: hsl(22, 100%, 81%);
 }
 
 [data-rich-colors='true'] [data-sonner-toast][data-type='success'] {
@@ -403,6 +411,18 @@
   background: var(--error-bg);
   border-color: var(--error-border);
   color: var(--error-text);
+}
+
+[data-rich-colors='true'] [data-sonner-toast][data-type='warning'] {
+  background: var(--warning-bg);
+  border-color: var(--warning-border);
+  color: var(--warning-text);
+}
+
+[data-rich-colors='true'] [data-sonner-toast][data-type='warning'] [data-close-button] {
+  background: var(--warning-bg);
+  border-color: var(--warning-border);
+  color: var(--warning-text);
 }
 
 .sonner-loading-wrapper {

--- a/src/styles.css
+++ b/src/styles.css
@@ -354,9 +354,9 @@
   --error-border: hsl(359, 100%, 94%);
   --error-text: hsl(360, 100%, 45%);
 
-  --warning-bg: hsl(24, 100%, 97%);
-  --warning-border: hsl(29, 100%, 94%);
-  --warning-text: hsl(26, 100%, 45%);
+  --warning-bg: hsl(49, 100%, 96%);
+  --warning-border: hsl(48, 100%, 88%);
+  --warning-text: hsl(22, 100%, 40%);
 }
 
 [data-sonner-toaster][data-theme='light'] [data-sonner-toast][data-invert='true'] {
@@ -384,9 +384,9 @@
   --error-border: hsl(357, 89%, 16%);
   --error-text: hsl(358, 100%, 81%);
 
-  --warning-bg: hsl(28, 76%, 10%);
-  --warning-border: hsl(24, 90%, 16%);
-  --warning-text: hsl(22, 100%, 81%);
+  --warning-bg: hsl(19, 86%, 8%);
+  --warning-border: hsl(23, 100%, 14%);
+  --warning-text: hsl(48, 100%, 74%);
 }
 
 [data-rich-colors='true'] [data-sonner-toast][data-type='success'] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type ToastTypes = 'normal' | 'action' | 'success' | 'error' | 'loading';
+export type ToastTypes = 'normal' | 'action' | 'success' | 'error' | 'warning' | 'loading';
 
 export type PromiseT = Promise<any> | (() => Promise<any>);
 

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -17,6 +17,9 @@ export default function Home() {
       <button data-testid="error" className="button" onClick={() => toast.error('My Error Toast')}>
         Render Error Toast
       </button>
+      <button data-testid="warning" className="button" onClick={() => toast.warning('My Warning Toast')}>
+        Render Warning Toast
+      </button>
       <button
         data-testid="action"
         className="button"
@@ -58,7 +61,7 @@ export default function Home() {
       >
         Render Custom Toast
       </button>
-      <Toaster />
+      <Toaster theme="dark" />
     </>
   );
 }

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -61,7 +61,7 @@ export default function Home() {
       >
         Render Custom Toast
       </button>
-      <Toaster theme="dark" />
+      <Toaster />
     </>
   );
 }

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -18,6 +18,9 @@ test.describe('Basic functionality', () => {
     await page.getByTestId('error').click();
     await expect(page.getByText('My Error Toast', { exact: true })).toHaveCount(1);
 
+    await page.getByTestId('warning').click();
+    await expect(page.getByText('My Warning Toast', { exact: true })).toHaveCount(1);
+
     await page.getByTestId('action').click();
     await expect(page.locator('[data-button]')).toHaveCount(1);
   });

--- a/website/src/components/Other/Other.tsx
+++ b/website/src/components/Other/Other.tsx
@@ -30,6 +30,14 @@ export const Other = ({
         },
       },
       {
+        name: 'Rich Colors Warning',
+        snippet: `toast.warning('Event did something unexpected')`,
+        action: () => {
+          toast.warning('Event did something unexpected');
+          setRichColors(true);
+        },
+      },
+      {
         name: 'Close Button',
         snippet: `toast('Event has been created', {
   description: 'Monday, January 3rd at 6:00pm',

--- a/website/src/components/Types/Types.tsx
+++ b/website/src/components/Types/Types.tsx
@@ -58,6 +58,11 @@ const allTypes = [
     action: () => toast.error('Event has not been created'),
   },
   {
+    name: 'Warning',
+    snippet: `toast.warning('Event did something unexpected')`,
+    action: () => toast.warning('Event did something unexpected'),
+  },
+  {
     name: 'Action',
     snippet: `toast('Event has been created', {
   action: {


### PR DESCRIPTION
Adds a new toast type of "warning"

<img width="394" alt="Screenshot 2023-03-14 at 11 27 54" src="https://user-images.githubusercontent.com/14224459/224956615-a3c63236-186e-4cee-b3f7-bd0c150eca3e.png">

I think it helps to differentiate between success, error and warning type toasts, and since I love this library and wanted to use a warning type, I thought I'd just add it here and create a PR in case you feel the same.

If you would prefer not to have a "warning" type toast, no problem.

Thanks!