### PR TITLE
Respect predefined theme

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -383,6 +383,7 @@ const Toaster = (props: ToasterProps) => {
   const [expanded, setExpanded] = React.useState(false);
   const [interacting, setInteracting] = React.useState(false);
   const [actualTheme, setActualTheme] = React.useState(
+    theme ||
     typeof window !== 'undefined'
       ? window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
         ? 'dark'


### PR DESCRIPTION
Predefined `theme="dark"` doesn't seem to be respected: 
![CleanShot 2023-07-10 at 13 35 00](https://github.com/emilkowalski/sonner/assets/28986134/a32824a5-c7cb-4b7d-962b-18649e844f3e)

This PR fixes it!