### PR TITLE
add finally to toast.promise

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -83,10 +83,12 @@ class Observer {
     p.then((promiseData) => {
       const message = typeof data.success === 'function' ? data.success(promiseData) : data.success;
       this.create({ id, type: 'success', message });
-    }).catch((error) => {
-      const message = typeof data.error === 'function' ? data.error(error) : data.error;
-      this.create({ id, type: 'error', message });
-    });
+    })
+      .catch((error) => {
+        const message = typeof data.error === 'function' ? data.error(error) : data.error;
+        this.create({ id, type: 'error', message });
+      })
+      .finally(data.finally);
     return id;
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type PromiseData<ToastData = any> = ExternalToast & {
   loading: string | React.ReactNode;
   success: string | React.ReactNode | ((data: ToastData) => React.ReactNode | string);
   error: string | React.ReactNode | ((error: any) => React.ReactNode | string);
+  finally?: () => void | Promise<void>;
 };
 
 export interface ToastT {

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -9,6 +9,7 @@ export default function Home({ searchParams }: any) {
   const [showAutoClose, setShowAutoClose] = React.useState(false);
   const [showDismiss, setShowDismiss] = React.useState(false);
   const [theme, setTheme] = React.useState(searchParams.theme || 'light');
+  const [isFinally, setIsFinally] = React.useState(false);
 
   return (
     <>
@@ -60,12 +61,14 @@ export default function Home({ searchParams }: any) {
       </button>
       <button
         data-testid="promise"
+        data-finally={isFinally ? '1' : '0'}
         className="button"
         onClick={() =>
           toast.promise(promise, {
             loading: 'Loading...',
             success: 'Loaded',
             error: 'Error',
+            finally: () => setIsFinally(true),
           })
         }
       >

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -26,6 +26,7 @@ test.describe('Basic functionality', () => {
     await page.getByTestId('promise').click();
     await expect(page.getByText('Loading...')).toHaveCount(1);
     await expect(page.getByText('Loaded')).toHaveCount(1);
+    await expect(page.getByTestId('promise')).toHaveAttribute('data-finally', '1');
   });
 
   test('render custom jsx in toast', async ({ page }) => {


### PR DESCRIPTION
Closes #117 

Adds the `finally` property to `toast.promise`. This property expects a function that will be called whenever the promise resolves or rejects — unlike the other properties, it does not have an effect on the rendered toast.