### PR TITLE
remove duplicated use client directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "import": "./dist/index.mjs",
     "require": "./dist/index.js"
   },
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,9 +8,4 @@ export default defineConfig({
   dts: true,
   format: ['esm', 'cjs'],
   injectStyle: true,
-  esbuildOptions(options) {
-    options.banner = {
-      js: '"use client"',
-    };
-  },
 });


### PR DESCRIPTION
* use relative path for ts type
* remove the esbuild `banner` as "use client" is already handled. now the `dist/index.js` only has one "use client" directive on top