### PR TITLE
Fix potential title and description overflowing

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -87,6 +87,7 @@ html[dir='rtl'],
     box-shadow 200ms;
   box-sizing: border-box;
   outline: none;
+  overflow-wrap: anywhere;
 }
 
 [data-sonner-toast][data-styled='true'] {


### PR DESCRIPTION
Before:
![CleanShot 2023-09-26 at 16 40 16@2x](https://github.com/emilkowalski/sonner/assets/25695219/8ca7a365-c47c-4429-99e7-f91b8871395f)

After
![CleanShot 2023-09-26 at 16 40 35@2x](https://github.com/emilkowalski/sonner/assets/25695219/2924b57c-fc48-4d46-b1ec-8b344a037270)

(Thanks for this amazing toaster package!)