### PR TITLE
Bugfix: Update now works for first toastId

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -8,7 +8,7 @@ import {
   ToastTypes,
 } from './types';
 
-let toastsCounter = 0;
+let toastsCounter = 1;
 
 class Observer {
   subscribers: Array<(toast: ExternalToast | ToastToDismiss) => void>;

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -126,6 +126,21 @@ export default function Home({ searchParams }: any) {
       >
         Non-dismissible Toast
       </button>
+      <button
+        data-testid="update-toast"
+        className="button"
+        onClick={() => {
+          const toastId = toast('My Unupdated Toast', {
+            duration: 10000,
+        });
+        toast('My Updated Toast', {
+            id: toastId,
+            duration: 10000,
+          });
+        }}
+      >
+        Updated Toast
+      </button>
       {showAutoClose ? <div data-testid="auto-close-el" /> : null}
       {showDismiss ? <div data-testid="dismiss-el" /> : null}
       <Toaster position={searchParams.position || 'bottom-right'} theme={theme} dir={searchParams.dir || 'auto'} />

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
@@ -158,5 +158,11 @@ test.describe('Basic functionality', () => {
     });
     await page.getByTestId('default-button').click();
     await expect(page.locator('[data-sonner-toaster]')).toHaveAttribute('dir', 'ltr');
+  });
+
+  test('show correct toast content when updating', async ({ page }) => {
+    await page.getByTestId('update-toast').click();
+    await expect(page.getByText('My Unupdated Toast')).toHaveCount(0);
+    await expect(page.getByText('My Updated Toast')).toHaveCount(1);
   });
 });


### PR DESCRIPTION
Fixes this issue: https://github.com/emilkowalski/sonner/issues/155

I went for the quick fix by setting `toasterCounter ` to start at 1 rather than 0.

If this is undesired, and you'd rather fix it by correcting the faulty comparisons, then that's understandable.

I added a test which should help you debug, regardless.