### PR TITLE
Typescript error - loading, success and error should be optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,9 +5,9 @@ export type ToastTypes = 'normal' | 'action' | 'success' | 'info' | 'warning' | 
 export type PromiseT<Data = any> = Promise<Data> | (() => Promise<Data>);
 
 export type PromiseData<ToastData = any> = ExternalToast & {
-  loading: string | React.ReactNode;
-  success: string | React.ReactNode | ((data: ToastData) => React.ReactNode | string);
-  error: string | React.ReactNode | ((error: any) => React.ReactNode | string);
+  loading?: string | React.ReactNode;
+  success?: string | React.ReactNode | ((data: ToastData) => React.ReactNode | string);
+  error?: string | React.ReactNode | ((error: any) => React.ReactNode | string);
   finally?: () => void | Promise<void>;
 };
 


### PR DESCRIPTION
It seems that loading, success and error was accidentally not marked as optional in `PromiseData`. Changing this allows typescript users not to get an error when not defining all three of the options.

The functionality to handle this also seems to be implemented in `state.ts`.