### PR TITLE
Returning the id for a custom toast

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -153,6 +153,7 @@ class Observer {
   custom = (jsx: (id: number | string) => React.ReactElement, data?: ExternalToast) => {
     const id = data?.id || toastsCounter++;
     this.publish({ jsx: jsx(id), id, ...data });
+    return id;
   };
 }
 


### PR DESCRIPTION
This function looks forgotten. Added the ability to get the id immediately after calling the function, as for all other toast functions