### PR TITLE
Account for fetch in promise

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -103,10 +103,7 @@ class Observer {
     return this.create({ ...data, type: 'loading', message });
   };
 
-  promise = <ToastData>(
-    promise: PromiseT<ToastData & { ok?: boolean; status?: string }>,
-    data?: PromiseData<ToastData>,
-  ) => {
+  promise = <ToastData>(promise: PromiseT<ToastData>, data?: PromiseData<ToastData>) => {
     if (!data) {
       // Nothing to show
       return;
@@ -127,9 +124,12 @@ class Observer {
     let shouldDismiss = id !== undefined;
 
     p.then((response) => {
-      if (response.ok !== undefined && !response.ok) {
+      // TODO: Clean up TS here, response has incorrect type
+      // @ts-expect-error
+      if (response && typeof response.ok === 'boolean' && !response.ok) {
         shouldDismiss = false;
         const message =
+          // @ts-expect-error
           typeof data.error === 'function' ? data.error(`HTTP error! status: ${response.status}`) : data.error;
         this.create({ id, type: 'error', message });
       } else if (data.success !== undefined) {

--- a/website/src/components/Types/Types.tsx
+++ b/website/src/components/Types/Types.tsx
@@ -114,6 +114,6 @@ toast.promise(promise, {
   {
     name: 'Custom',
     snippet: `toast(<div>A custom toast with default styling</div>)`,
-    action: () => toast(<div>A custom toast with default styling</div>),
+    action: () => toast(<div>A custom toast with default styling</div>, { duration: 1000000 }),
   },
 ];


### PR DESCRIPTION
The fetch API does not reject a promise on HTTP error status such as 404 or 500. Instead, it resolves the promise with the ok property set to false. So we add an additional check for the .ok property.