### PR TITLE
Resolves: #224 - Close button is always visible on toast when defined

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -218,7 +218,6 @@ html[dir='rtl'],
   border: 1px solid var(--gray4);
   transform: var(--toast-close-button-transform);
   border-radius: 50%;
-  opacity: 0;
   cursor: pointer;
   z-index: 1;
   transition: opacity 100ms, background 200ms, border-color 200ms;
@@ -230,16 +229,6 @@ html[dir='rtl'],
 
 [data-sonner-toast] [data-disabled='true'] {
   cursor: not-allowed;
-}
-
-[data-sonner-toast]:hover [data-close-button] {
-  opacity: 1;
-}
-[data-sonner-toast]:focus [data-close-button] {
-  opacity: 1;
-}
-[data-sonner-toast]:focus-within [data-close-button] {
-  opacity: 1;
 }
 
 [data-sonner-toast]:hover [data-close-button]:hover {


### PR DESCRIPTION
Small styling change that makes the close button visible by default when closeButton prop is passed. Thus making the component more accessible.

---

Closed this originally, as I thought this had introduced a bug, but seems to be the nuance of the global Toaster component not really handling toggling the close functionality on/off dynamically. E.g. you click the close example, and then access toasts from there, they will also have the close button. 

I did think you could just `setCloseButton` to false on dismiss / autoclose, but that would have other side effects - like when viewing multiple toasts with close on.