### PR TITLE
types: change label types to ReactNode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -361,7 +361,7 @@ const Toast = (props: ToastProps) => {
               data-button
               data-cancel
               style={toast.cancelButtonStyle || cancelButtonStyle}
-              onClick={() => {
+              onClick={(event) => {
                 if (!dismissible) return;
                 deleteToast();
                 if (toast.cancel?.onClick) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -365,7 +365,7 @@ const Toast = (props: ToastProps) => {
                 if (!dismissible) return;
                 deleteToast();
                 if (toast.cancel?.onClick) {
-                  toast.cancel.onClick();
+                  toast.cancel.onClick(event);
                 }
               }}
               className={cn(classNames?.cancelButton, toast?.classNames?.cancelButton)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,11 +39,11 @@ export interface ToastT {
   delete?: boolean;
   important?: boolean;
   action?: {
-    label: string;
+    label: React.ReactNode;
     onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   };
   cancel?: {
-    label: string;
+    label: React.ReactNode;
     onClick?: () => void;
   };
   onDismiss?: (toast: ToastT) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface ToastT {
   };
   cancel?: {
     label: React.ReactNode;
-    onClick?: () => void;
+    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   };
   onDismiss?: (toast: ToastT) => void;
   onAutoClose?: (toast: ToastT) => void;


### PR DESCRIPTION
Just started using sonner and realized `action.label` & `cancel.label` could accept `ReactNode` instead of `string` so you can pass in a more complex custom label including an icon or whatever.

Hope you agree, if not I'd be curious of possible downsides I might not've considered and can be closed.

Closes: #273

Also just saw that `cancel.onClick` is typed `onClick?: () => void;` while `action.onclick` = `onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;` is there a reason or should I open another PR to add the event to `cancel.onClick` as well?