### PR TITLE
refactor: remove unused remaining time ref

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,7 +83,6 @@ const Toast = (props: ToastProps) => {
   );
   const closeTimerStartTimeRef = React.useRef(0);
   const offset = React.useRef(0);
-  const closeTimerRemainingTimeRef = React.useRef(duration);
   const lastCloseTimerStartTimeRef = React.useRef(0);
   const pointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
   const [y, x] = position.split('-');


### PR DESCRIPTION
After the changes in [this PR](https://github.com/emilkowalski/sonner/pull/206), the`closeTimerRemainingTimeRef` ref is no longer used. This PR removes it.