### PR TITLE
Implement option to pause when document is hidden

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const useIsDocumentHidden = () => {
+  const [isDocumentHidden, setIsDocumentHidden] = React.useState(false);
+
+  React.useEffect(() => {
+    const callback = () => {
+      setIsDocumentHidden(document.hidden);
+    };
+    document.addEventListener('visibilitychange', callback);
+    return () => window.removeEventListener('visibilitychange', callback);
+  }, []);
+
+  return isDocumentHidden;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,7 +58,7 @@ const Toast = (props: ToastProps) => {
     expandByDefault,
     classNames,
     closeButtonAriaLabel = 'Close toast',
-    pauseWhenDocumentHidden,
+    pauseWhenPageIsHidden,
   } = props;
   const [mounted, setMounted] = React.useState(false);
   const [removed, setRemoved] = React.useState(false);
@@ -168,7 +168,7 @@ const Toast = (props: ToastProps) => {
       }, remainingTime);
     };
 
-    if (expanded || interacting || (pauseWhenDocumentHidden && isDocumentHidden)) {
+    if (expanded || interacting || (pauseWhenPageIsHidden && isDocumentHidden)) {
       pauseTimer();
     } else {
       startTimer();
@@ -184,7 +184,7 @@ const Toast = (props: ToastProps) => {
     deleteToast,
     toast.promise,
     toastType,
-    pauseWhenDocumentHidden,
+    pauseWhenPageIsHidden,
     isDocumentHidden,
   ]);
 
@@ -440,7 +440,7 @@ const Toaster = (props: ToasterProps) => {
     gap,
     loadingIcon,
     containerAriaLabel = 'Notifications',
-    pauseWhenDocumentHidden,
+    pauseWhenPageIsHidden,
   } = props;
   const [toasts, setToasts] = React.useState<ToastT[]>([]);
   const possiblePositions = React.useMemo(() => {
@@ -661,7 +661,7 @@ const Toaster = (props: ToasterProps) => {
                   gap={gap}
                   loadingIcon={loadingIcon}
                   expanded={expanded}
-                  pauseWhenDocumentHidden={pauseWhenDocumentHidden}
+                  pauseWhenPageIsHidden={pauseWhenPageIsHidden}
                 />
               ))}
           </ol>

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,7 @@ export interface ToasterProps {
   dir?: 'rtl' | 'ltr' | 'auto';
   loadingIcon?: React.ReactNode;
   containerAriaLabel?: string;
+  pauseWhenDocumentHidden?: boolean;
 }
 
 export interface ToastProps {
@@ -126,6 +127,7 @@ export interface ToastProps {
   loadingIcon?: React.ReactNode;
   classNames?: ToastClassnames;
   closeButtonAriaLabel?: string;
+  pauseWhenDocumentHidden: boolean;
 }
 
 export enum SwipeStateTypes {

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,7 @@ export interface ToasterProps {
   dir?: 'rtl' | 'ltr' | 'auto';
   loadingIcon?: React.ReactNode;
   containerAriaLabel?: string;
-  pauseWhenDocumentHidden?: boolean;
+  pauseWhenPageIsHidden?: boolean;
 }
 
 export interface ToastProps {
@@ -127,7 +127,7 @@ export interface ToastProps {
   loadingIcon?: React.ReactNode;
   classNames?: ToastClassnames;
   closeButtonAriaLabel?: string;
-  pauseWhenDocumentHidden: boolean;
+  pauseWhenPageIsHidden: boolean;
 }
 
 export enum SwipeStateTypes {

--- a/website/src/pages/toaster.mdx
+++ b/website/src/pages/toaster.mdx
@@ -49,18 +49,19 @@ Changes the directionality of the toast's text.
 
 ## API Reference
 
-| Property      |                                            Description                                             |        Default |
-| :------------ | :------------------------------------------------------------------------------------------------: | -------------: |
-| theme         |                         Toast's theme, either `light`, `dark`, or `system`                         |        `light` |
-| richColors    |                            Makes error and success state more colorful                             |        `false` |
-| expand        |                                 Toasts will be expanded by default                                 |        `false` |
-| visibleToasts |                                      Amount of visible toasts                                      |            `3` |
-| position      |                              Place where the toasts will be rendered                               | `bottom-right` |
-| closeButton   |                         Adds a close button to all toasts, shows on hover                          |        `false` |
-| offset        |                                Offset from the edges of the screen.                                |         `32px` |
-| dir           |                                   Directionality of toast's text                                   |          `ltr` |
-| hotkey        |                    Keyboard shortcut that will move focus to the toaster area.                     |    `⌥/alt + T` |
-| invert        |                             Dark toasts in light mode and vice versa.                              |        `false` |
-| toastOptions  | These will act as default options for all toasts. See [toast()](/toast) for all available options. |         `4000` |
-| gap           |                                  Gap between toasts when expanded                                  |           `14` |
-| loadingIcon   |                                  Changes the default loading icon                                  |            `-` |
+| Property                |                                            Description                                             |        Default |
+| :---------------------- | :------------------------------------------------------------------------------------------------: | -------------: |
+| theme                   |                         Toast's theme, either `light`, `dark`, or `system`                         |        `light` |
+| richColors              |                            Makes error and success state more colorful                             |        `false` |
+| expand                  |                                 Toasts will be expanded by default                                 |        `false` |
+| visibleToasts           |                                      Amount of visible toasts                                      |            `3` |
+| position                |                              Place where the toasts will be rendered                               | `bottom-right` |
+| closeButton             |                         Adds a close button to all toasts, shows on hover                          |        `false` |
+| offset                  |                                Offset from the edges of the screen.                                |         `32px` |
+| dir                     |                                   Directionality of toast's text                                   |          `ltr` |
+| hotkey                  |                    Keyboard shortcut that will move focus to the toaster area.                     |    `⌥/alt + T` |
+| invert                  |                             Dark toasts in light mode and vice versa.                              |        `false` |
+| toastOptions            | These will act as default options for all toasts. See [toast()](/toast) for all available options. |         `4000` |
+| gap                     |                                  Gap between toasts when expanded                                  |           `14` |
+| loadingIcon             |                                  Changes the default loading icon                                  |            `-` |
+| pauseWhenDocumentHidden |                            Pauses toast timers when document is hidden.                            |        `false` |

--- a/website/src/pages/toaster.mdx
+++ b/website/src/pages/toaster.mdx
@@ -49,19 +49,19 @@ Changes the directionality of the toast's text.
 
 ## API Reference
 
-| Property                |                                            Description                                             |        Default |
-| :---------------------- | :------------------------------------------------------------------------------------------------: | -------------: |
-| theme                   |                         Toast's theme, either `light`, `dark`, or `system`                         |        `light` |
-| richColors              |                            Makes error and success state more colorful                             |        `false` |
-| expand                  |                                 Toasts will be expanded by default                                 |        `false` |
-| visibleToasts           |                                      Amount of visible toasts                                      |            `3` |
-| position                |                              Place where the toasts will be rendered                               | `bottom-right` |
-| closeButton             |                         Adds a close button to all toasts, shows on hover                          |        `false` |
-| offset                  |                                Offset from the edges of the screen.                                |         `32px` |
-| dir                     |                                   Directionality of toast's text                                   |          `ltr` |
-| hotkey                  |                    Keyboard shortcut that will move focus to the toaster area.                     |    `⌥/alt + T` |
-| invert                  |                             Dark toasts in light mode and vice versa.                              |        `false` |
-| toastOptions            | These will act as default options for all toasts. See [toast()](/toast) for all available options. |         `4000` |
-| gap                     |                                  Gap between toasts when expanded                                  |           `14` |
-| loadingIcon             |                                  Changes the default loading icon                                  |            `-` |
-| pauseWhenDocumentHidden |                            Pauses toast timers when document is hidden.                            |        `false` |
+| Property              |                                                           Description                                                           |        Default |
+| :-------------------- | :-----------------------------------------------------------------------------------------------------------------------------: | -------------: |
+| theme                 |                                       Toast's theme, either `light`, `dark`, or `system`                                        |        `light` |
+| richColors            |                                           Makes error and success state more colorful                                           |        `false` |
+| expand                |                                               Toasts will be expanded by default                                                |        `false` |
+| visibleToasts         |                                                    Amount of visible toasts                                                     |            `3` |
+| position              |                                             Place where the toasts will be rendered                                             | `bottom-right` |
+| closeButton           |                                        Adds a close button to all toasts, shows on hover                                        |        `false` |
+| offset                |                                              Offset from the edges of the screen.                                               |         `32px` |
+| dir                   |                                                 Directionality of toast's text                                                  |          `ltr` |
+| hotkey                |                                   Keyboard shortcut that will move focus to the toaster area.                                   |    `⌥/alt + T` |
+| invert                |                                            Dark toasts in light mode and vice versa.                                            |        `false` |
+| toastOptions          |               These will act as default options for all toasts. See [toast()](/toast) for all available options.                |         `4000` |
+| gap                   |                                                Gap between toasts when expanded                                                 |           `14` |
+| loadingIcon           |                                                Changes the default loading icon                                                 |            `-` |
+| pauseWhenPageIsHidden | Pauses toast timers when the page is hidden, e.g., when the tab is backgrounded, the browser is minimized, or the OS is locked. |        `false` |


### PR DESCRIPTION
### Issue 😱:

Closes https://github.com/emilkowalski/sonner/issues/303

### What has been done ✅:

- Create `useIsDocumentHidden` hook
- Add `pauseWhenDocumentHidden` prop to `Toast` and `Toaster`
- Add logic to pause `Toast` timers when document is hidden
- Document prop for `Toaster`

### Screenshots/Videos 🎥:

N/A
