### PR TITLE
ghost-div doesn't block click in Firefox

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -269,6 +269,7 @@ html[dir='rtl'],
   left: 0;
   right: 0;
   height: 100%;
+  z-index: -1;
 }
 
 [data-sonner-toast][data-y-position='top'][data-swiping='true']:before {


### PR DESCRIPTION
### Issue 😱:

Closes https://github.com/emilkowalski/sonner/issues/258

### What has been done ✅:

- Moved ghost-div in before-meta tag one level behind to make sure it doesn't block the clickable area

### Screenshots/Videos 🎥:

N/A
