### PR TITLE
Avoid issues with `<li>` offest when using different positions

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -641,8 +641,8 @@ const Toaster = (props: ToasterProps) => {
                   cancelButtonStyle={toastOptions?.cancelButtonStyle}
                   actionButtonStyle={toastOptions?.actionButtonStyle}
                   removeToast={removeToast}
-                  toasts={toasts}
-                  heights={heights}
+                  toasts={toasts.filter(t => t.position == toast.position)}
+                  heights={heights.filter(h => h.position == toast.position)}
                   setHeights={setHeights}
                   expandByDefault={expand}
                   gap={gap}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,7 +123,7 @@ const Toast = (props: ToastProps) => {
     setHeights((heights) => {
       const alreadyExists = heights.find((height) => height.toastId === toast.id);
       if (!alreadyExists) {
-        return [{ toastId: toast.id, height: newHeight }, ...heights];
+        return [{ toastId: toast.id, height: newHeight, position: toast.position }, ...heights];
       } else {
         return heights.map((height) => (height.toastId === toast.id ? { ...height, height: newHeight } : height));
       }
@@ -184,7 +184,7 @@ const Toast = (props: ToastProps) => {
 
       // Add toast height tot heights array after the toast is mounted
       setInitialHeight(height);
-      setHeights((h) => [{ toastId: toast.id, height }, ...h]);
+      setHeights((h) => [{ toastId: toast.id, height, position: toast.position }, ...h]);
 
       return () => setHeights((h) => h.filter((height) => height.toastId !== toast.id));
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export type Position = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
 export interface HeightT {
   height: number;
   toastId: number | string;
+  position: Position;
 }
 
 interface ToastOptions {


### PR DESCRIPTION
### Issue 😱:
Toast position breaks when firing toasts in different positions

Closes https://github.com/emilkowalski/sonner/issues/311

### What has been done ✅:

- `positions` prop added to `HeightT` interface
- new `positions` prop is used to filter toasts and heights when calculating the offset of the element `<li>`

### Screenshots/Videos 🎥:
You can fire toasts in different position without messing with the offset.
<img width="693" alt="image" src="https://github.com/emilkowalski/sonner/assets/16542378/c627cc8a-5eae-4f1f-b26b-4e09138382be">

