### PR TITLE
Renaming too general className with project-specific one (#305)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -195,7 +195,7 @@ const Toast = (props: ToastProps) => {
   function getLoadingIcon() {
     if (loadingIconProp) {
       return (
-        <div className="loader" data-visible={toastType === 'loading'}>
+        <div className="sonner-loader" data-visible={toastType === 'loading'}>
           {loadingIconProp}
         </div>
       );

--- a/src/styles.css
+++ b/src/styles.css
@@ -646,7 +646,7 @@ html[dir='rtl'],
   }
 }
 
-.loader {
+.sonner-loader {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -657,7 +657,7 @@ html[dir='rtl'],
     transform 200ms;
 }
 
-.loader[data-visible='false'] {
+.sonner-loader[data-visible='false'] {
   opacity: 0;
   transform: scale(0.8) translate(-50%, -50%);
 }


### PR DESCRIPTION
### Issue 😱:

Closes https://github.com/emilkowalski/sonner/issues/305

### What has been done ✅:

- Replaced the generic .loader class with the project specific .sonner-loader to prevent conflicts with other projects

### Screenshots/Videos 🎥:

N/A
