### PR TITLE
Make the toast content grow to fill remaining space

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -179,6 +179,7 @@ html[dir='rtl'],
 }
 
 [data-sonner-toast] [data-content] {
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   gap: 2px;


### PR DESCRIPTION
At the moment, the content div only takes up as much space as is needed for the title/description of the toast.

This caused a problem for me when I rendered a progress bar in the toast description. By default, the progress bar was only as wide as the title, so it looked a bit funny. This PR fixes that by making the content grow to fill available space, so that variable-width items like progress bars take up the full content area by default.