### PR TITLE
refactor: remove copy-to-clipboard dependency

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,6 @@
     "@types/react-dom": "18.0.10",
     "@vercel/analytics": "^1.1.0",
     "clsx": "^2.0.0",
-    "copy-to-clipboard": "^3.3.3",
     "eslint-config-next": "^13.2.3",
     "framer-motion": "^9.0.1",
     "next": "13.4.19",

--- a/website/src/components/CodeBlock/index.tsx
+++ b/website/src/components/CodeBlock/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import useMeasure from 'react-use-measure';
-import copy from 'copy-to-clipboard';
 import { AnimatePresence, motion, MotionConfig } from 'framer-motion';
 
 import styles from './code-block.module.css';
@@ -50,7 +49,7 @@ export const CodeBlock = ({ children, initialHeight = 0 }: { children: string; i
   const [copying, setCopying] = React.useState<number>(0);
 
   const onCopy = React.useCallback(() => {
-    copy(children);
+    navigator.clipboard.writeText(children)
     setCopying((c) => c + 1);
     setTimeout(() => {
       setCopying((c) => c - 1);

--- a/website/src/components/Installation/index.tsx
+++ b/website/src/components/Installation/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import copy from 'copy-to-clipboard';
 import { motion, AnimatePresence, MotionConfig } from 'framer-motion';
 
 import styles from './installation.module.css';
@@ -15,7 +14,7 @@ export const Installation = () => {
   const [copying, setCopying] = React.useState(0);
 
   const onCopy = React.useCallback(() => {
-    copy('npm install sonner');
+    navigator.clipboard.writeText('npm install sonner')
     setCopying((c) => c + 1);
     setTimeout(() => {
       setCopying((c) => c - 1);


### PR DESCRIPTION
This dependency isn't necessary anymore since the clipboard API in the browser is widely adopted 🙂

https://caniuse.com/mdn-api_clipboard_writetext

I tried to regenerate the lockfile but it's failing on my local, not sure why 😢