### PR TITLE
Add classNames.icon option

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -362,7 +362,7 @@ const Toast = (props: ToastProps) => {
       ) : (
         <>
           {toastType || toast.icon || toast.promise ? (
-            <div data-icon="">
+            <div data-icon="" className={cn(classNames?.icon, toast?.classNames?.icon)}>
               {toast.promise || toastType === 'loading'
                 ? toast.icon || icons?.loading || getLoadingIcon()
                 : toast.icon || icons?.[toastType] || getAsset(toastType)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface ToastClassnames {
   toast?: string;
   title?: string;
   description?: string;
+  icon?: string;
   loader?: string;
   closeButton?: string;
   cancelButton?: string;


### PR DESCRIPTION
### What has been done ✅:

I added an `icon` property to the `classNames` toast option. This allows users to style the `<div data-icon="">` element using tailwind. This would be very useful to give the icon common styles like width/height:

```ts
<Toaster
  toastOptions={{
    unstyled: true,
    classNames: {
      icon: "size-6"
    },
  }}
/>
```

Currently, I have to add the `size-6` classname to each icon in my icons override:

```ts
<Toaster
  icons={{
    error: <ExclamationCircleIcon className="size-6" />,
    warning: <ExclamationTriangleIcon className="size-6" />,
    info: <InformationCircleIcon className="size-6" />,
    success: <CheckCircleIcon className="size-6" />,
  }}
/>
```