### PR TITLE
Add example for loading type + include loader on loading type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -363,9 +363,7 @@ const Toast = (props: ToastProps) => {
         <>
           {toastType || toast.icon || toast.promise ? (
             <div data-icon="">
-              {toast.promise && toast.type === 'loading' && !toast.icon
-                ? toast.icon || icons?.loading || getLoadingIcon()
-                : null}
+              {toast.type === 'loading' && !toast.icon ? toast.icon || icons?.loading || getLoadingIcon() : null}
               {toast.type !== 'loading' ? toast.icon || icons?.[toastType] || getAsset(toastType) : null}
             </div>
           ) : null}

--- a/website/src/components/Types/Types.tsx
+++ b/website/src/components/Types/Types.tsx
@@ -84,6 +84,26 @@ const allTypes = [
       }),
   },
   {
+    name: 'Loading',
+    snippet: `
+const loadingId = toast.loading('Loading...');
+...
+toast.success('Done loading', {
+	id: loadingId
+})
+`,
+    action: () => {
+      const loadingId = toast.loading('Loading...');
+      new Promise((resolve) => {
+        setTimeout(() => {
+          toast.success('Done loading', {
+            id: loadingId,
+          });
+        }, 2000);
+      });
+    },
+  },
+  {
     name: 'Promise',
     snippet: `const promise = () => new Promise((resolve) => setTimeout(() => resolve({ name: 'Sonner' }), 2000));
 


### PR DESCRIPTION
### Issue 😱:

Closes https://github.com/emilkowalski/sonner/issues/354

### What has been done ✅:
- Added an example to the home page for the loading type
- Removed the promise check for a loading spinner (If there is a preferred alternative fix please let me know ☺️)

### Screenshots/Videos 🎥:
<img width="684" alt="Screenshot 2024-02-27 at 1 08 21 AM" src="https://github.com/emilkowalski/sonner/assets/7637729/79657c28-f657-45a1-8467-7ed3e8d33adf">
<img width="399" alt="Screenshot 2024-02-27 at 1 10 08 AM" src="https://github.com/emilkowalski/sonner/assets/7637729/fb4d9d87-f63c-499e-afc9-b0e049d19902">
