### PR TITLE
fix: dynamic mobile width based on `--mobile-offset`

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -360,7 +360,7 @@ html[dir='rtl'],
   [data-sonner-toaster] [data-sonner-toast] {
     left: 0;
     right: 0;
-    width: calc(100% - 32px);
+    width: calc(100% - var(--mobile-offset) * 2);
   }
 
   [data-sonner-toaster][data-x-position='left'] {


### PR DESCRIPTION
### Issue 😱:

Closes #370

### What has been done ✅:

Calculate the mobile width based on `--mobile-offset` instead of a hardcoded value to make it always centered. 

### Screenshots/Videos 🎥:

**Before**
<img width="433" alt="image" src="https://github.com/emilkowalski/sonner/assets/43892874/384caa3f-4a65-4b8c-8cb7-d34112612037">

**After**
<img width="433" alt="image" src="https://github.com/emilkowalski/sonner/assets/43892874/3712aa4a-d07d-4312-b3cd-7c98bb2d2ebd">
