### PR TITLE
fix: toast not displaying when `Toaster.duration` is set to Infinity

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -168,6 +168,11 @@ const Toast = (props: ToastProps) => {
     };
 
     const startTimer = () => {
+      // setTimeout(, Infinity) behaves as if the delay is 0.
+      // As a result, the toast would be closed immediately, giving the appearance that it was never rendered.
+      // See: https://github.com/denysdovhan/wtfjs?tab=readme-ov-file#an-infinite-timeout
+      if (remainingTime === Infinity) return;
+
       closeTimerStartTimeRef.current = new Date().getTime();
 
       // Let the toast know it has started


### PR DESCRIPTION
### Issue 😱:

Closes #340 

### What has been done ✅:

`setTimeout(, Infinity)` behaves as if the delay is 0.
As a result, the toast would be closed immediately, giving the appearance that it was never rendered.

To solve this, we skip setting the timer for closing the toast.

### Screenshots/Videos 🎥:

N/A
