### PR TITLE
fix: `Toaster.gap` doesn't work

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -617,7 +617,7 @@ const Toaster = (props: ToasterProps) => {
                 '--front-toast-height': `${heights[0]?.height || 0}px`,
                 '--offset': typeof offset === 'number' ? `${offset}px` : offset || VIEWPORT_OFFSET,
                 '--width': `${TOAST_WIDTH}px`,
-                '--gap': `${GAP}px`,
+                '--gap': `${gap}px`,
                 ...style,
               } as React.CSSProperties
             }


### PR DESCRIPTION
### Issue 😱:

Closes #374 

### What has been done ✅:

Use the `gap` prop instead of the fixed `GAP` constant.


