### PR TITLE
allow user to use React elements also inside toaster

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -383,9 +383,12 @@ const Toast = (props: ToastProps) => {
           ) : null}
 
           <div data-content="" className={cn(classNames?.content)}>
-            <div data-title="" className={cn(classNames?.title, toast?.classNames?.title)}
-                 dangerouslySetInnerHTML={sanitizeHTML(toast.title as string)}
-            ></div>
+            <div data-title="" className={cn(classNames?.title, toast?.classNames?.title)}>
+              { typeof toast.title === 'string'
+                  ? <div dangerouslySetInnerHTML={sanitizeHTML(toast.title)} />
+                  : toast.title
+              }
+            </div>
             {toast.description ? (
               <div
                 data-description=""
@@ -395,8 +398,12 @@ const Toast = (props: ToastProps) => {
                   classNames?.description,
                   toast?.classNames?.description,
                 )}
-                dangerouslySetInnerHTML={sanitizeHTML(toast.description as string)}
-              ></div>
+              >
+                { typeof toast.description === 'string'
+                    ? <div dangerouslySetInnerHTML={sanitizeHTML(toast.description)} />
+                    : toast.description
+                }
+              </div>
             ) : null}
           </div>
           {toast.cancel ? (


### PR DESCRIPTION
### Issue 😱:

Closes https://github.com/emilkowalski/sonner/issues/378

allow the user to use React elements within the toaster description section. ✅ 



### Screenshots/Videos 🎥:

![Screenshot 2024-03-21 at 09 51 00](https://github.com/emilkowalski/sonner/assets/16780483/126e0cf8-9720-4802-b223-eb5f08c381fb)
![Screenshot 2024-03-21 at 09 54 50](https://github.com/emilkowalski/sonner/assets/16780483/5c592816-baf9-4ef3-bd26-64e43ee36f73)

