### PR TITLE
Handle async functions in `toast.promise` results

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -125,17 +125,13 @@ class Observer {
     let shouldDismiss = id !== undefined;
 
     p.then(async (response) => {
-      // TODO: Clean up TS here, response has incorrect type
-      // @ts-expect-error
-      if (response && typeof response.ok === 'boolean' && !response.ok) {
+      if (isHttpResponse(response) && !response.ok) {
         shouldDismiss = false;
         const message =
-          // @ts-expect-error
           typeof data.error === 'function' ? await data.error(`HTTP error! status: ${response.status}`) : data.error;
         const description =
           typeof data.description === 'function'
-            ? // @ts-expect-error
-              await data.description(`HTTP error! status: ${response.status}`)
+            ? await data.description(`HTTP error! status: ${response.status}`)
             : data.description;
         this.create({ id, type: 'error', message, description });
       } else if (data.success !== undefined) {
@@ -186,6 +182,17 @@ const toastFunction = (message: string | React.ReactNode, data?: ExternalToast) 
     id,
   });
   return id;
+};
+
+const isHttpResponse = (data: any): data is Response => {
+  return (
+    data &&
+    typeof data === 'object' &&
+    'ok' in data &&
+    typeof data.ok === 'boolean' &&
+    'status' in data &&
+    typeof data.status === 'number'
+  );
 };
 
 const basicToast = toastFunction;

--- a/src/state.ts
+++ b/src/state.ts
@@ -124,32 +124,33 @@ class Observer {
 
     let shouldDismiss = id !== undefined;
 
-    p.then((response) => {
+    p.then(async (response) => {
       // TODO: Clean up TS here, response has incorrect type
       // @ts-expect-error
       if (response && typeof response.ok === 'boolean' && !response.ok) {
         shouldDismiss = false;
         const message =
           // @ts-expect-error
-          typeof data.error === 'function' ? data.error(`HTTP error! status: ${response.status}`) : data.error;
+          typeof data.error === 'function' ? await data.error(`HTTP error! status: ${response.status}`) : data.error;
         const description =
           typeof data.description === 'function'
             ? // @ts-expect-error
-              data.description(`HTTP error! status: ${response.status}`)
+              await data.description(`HTTP error! status: ${response.status}`)
             : data.description;
         this.create({ id, type: 'error', message, description });
       } else if (data.success !== undefined) {
         shouldDismiss = false;
-        const message = typeof data.success === 'function' ? data.success(response) : data.success;
-        const description = typeof data.description === 'function' ? data.description(response) : data.description;
+        const message = typeof data.success === 'function' ? await data.success(response) : data.success;
+        const description =
+          typeof data.description === 'function' ? await data.description(response) : data.description;
         this.create({ id, type: 'success', message, description });
       }
     })
-      .catch((error) => {
+      .catch(async (error) => {
         if (data.error !== undefined) {
           shouldDismiss = false;
-          const message = typeof data.error === 'function' ? data.error(error) : data.error;
-          const description = typeof data.description === 'function' ? data.description(error) : data.description;
+          const message = typeof data.error === 'function' ? await data.error(error) : data.error;
+          const description = typeof data.description === 'function' ? await data.description(error) : data.description;
           this.create({ id, type: 'error', message, description });
         }
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,13 +4,18 @@ export type ToastTypes = 'normal' | 'action' | 'success' | 'info' | 'warning' | 
 
 export type PromiseT<Data = any> = Promise<Data> | (() => Promise<Data>);
 
+export type PromiseTResult<Data = any> =
+  | string
+  | React.ReactNode
+  | ((data: Data) => React.ReactNode | string | Promise<React.ReactNode | string>);
+
 export type PromiseExternalToast = Omit<ExternalToast, 'description'>;
 
 export type PromiseData<ToastData = any> = PromiseExternalToast & {
   loading?: string | React.ReactNode;
-  success?: string | React.ReactNode | ((data: ToastData) => React.ReactNode | string);
-  error?: string | React.ReactNode | ((error: any) => React.ReactNode | string);
-  description?: string | React.ReactNode | ((data: any) => React.ReactNode | string);
+  success?: PromiseTResult<ToastData>;
+  error?: PromiseTResult;
+  description?: PromiseTResult;
   finally?: () => void | Promise<void>;
 };
 


### PR DESCRIPTION
### Issue:

Async functions in `toast.promise` will lead to toasts with the message: `[object Promise]`

### What has been done:

- [x] Added an optional `Promise<React.ReactNode>` return type on the `success`, `error` and `description` functions of `toast.promise`.
- [x] Awaited the `success`, `error` and `description` functions.
- [x] Cleaned up `ts-expect-error` declarations marked as todo, by introducing a type guard for the `Response` type.

### Screenshots/Videos:

<img width="367" alt="Screenshot 2024-03-28 at 17 44 02" src="https://github.com/emilkowalski/sonner/assets/57961822/54bcdc95-7cb8-49bc-b3a5-ffc1b71d9113">

---

@emilkowalski Any reason why `toast.promise` doesn't return a promise that resolves when its input promise resolves? Any chance I can implement #339 ? 
