### PR TITLE
fix: remove repeat effect hook to resolve mix up

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -211,20 +211,6 @@ const Toast = (props: ToastProps) => {
   ]);
 
   React.useEffect(() => {
-    const toastNode = toastRef.current;
-
-    if (toastNode) {
-      const height = toastNode.getBoundingClientRect().height;
-
-      // Add toast height tot heights array after the toast is mounted
-      setInitialHeight(height);
-      setHeights((h) => [{ toastId: toast.id, height, position: toast.position }, ...h]);
-
-      return () => setHeights((h) => h.filter((height) => height.toastId !== toast.id));
-    }
-  }, [setHeights, toast.id]);
-
-  React.useEffect(() => {
     if (toast.delete) {
       deleteToast();
     }


### PR DESCRIPTION
### Issue:

fix https://github.com/emilkowalski/sonner/issues/391

### What has been done:

`useEffect` and `useLayoutEffect` both listen to toast.id and include the same logic, so remove the repeated calls to cancel the duplicate toast array

### Screenshots/Videos:

![Kapture 2024-04-02 at 11 29 40](https://github.com/emilkowalski/sonner/assets/37643993/f12e418e-3ef7-4a12-8858-445e7c65ce7f)


