### PR TITLE
feat: updates toast action/cancel property type/handlers

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -418,8 +418,8 @@ const Toast = (props: ToastProps) => {
                 // We need to check twice because typescript
                 if (!isAction(toast.cancel)) return;
                 if (!dismissible) return;
+                toast.cancel.onClick?.(event);
                 deleteToast();
-                toast.cancel.onClick(event);
               }}
               className={cn(classNames?.cancelButton, toast?.classNames?.cancelButton)}
             >
@@ -430,13 +430,14 @@ const Toast = (props: ToastProps) => {
             toast.action
           ) : toast.action && isAction(toast.action) ? (
             <button
-              data-button=""
+              data-button
+							data-action
               style={toast.actionButtonStyle || actionButtonStyle}
               onClick={(event) => {
                 // We need to check twice because typescript
                 if (!isAction(toast.action)) return;
-                toast.action.onClick(event);
                 if (event.defaultPrevented) return;
+                toast.action.onClick?.(event);
                 deleteToast();
               }}
               className={cn(classNames?.actionButton, toast?.classNames?.actionButton)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export interface ToastIcons {
 }
 
 interface Action {
-  label: string;
+  label: React.ReactNode;
   onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   actionButtonStyle?: React.CSSProperties;
 }
@@ -75,7 +75,7 @@ export interface ToastT {
 }
 
 export function isAction(action: Action | React.ReactNode): action is Action {
-  return (action as Action).label !== undefined && typeof (action as Action).onClick === 'function';
+  return (action as Action).label !== undefined;
 }
 
 export type Position = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'top-center' | 'bottom-center';


### PR DESCRIPTION
### Issue:

Closes https://github.com/emilkowalski/sonner/issues/397

### What has been done:

- [x] Changes `Action.label` type to React.ReactNode
- [x] Removes required function check on `isAction` helper
- [x] Handles action/cancel optional `onClick` property

### Screenshots/Videos:

N/A
