### PR TITLE
export ToasterProps type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -716,4 +716,4 @@ const Toaster = (props: ToasterProps) => {
     </section>
   );
 };
-export { toast, Toaster, type ExternalToast, type ToastT };
+export { toast, Toaster, type ExternalToast, type ToastT, type ToasterProps };


### PR DESCRIPTION
For Sonner to be bundled in other libraries, we need to export `ToasterProps`.

This fixes following error for library authors:
```
TS4023: Exported variable 'X' has or is using name 'ToasterProps' from external module './node_modules/sonner/dist/index' but cannot be named
```

### Issue:

Closes https://github.com/emilkowalski/sonner/issues/399

### What has been done:

- exported `ToasterProps` from index
