### PR TITLE
fix: media query event listener in older safari versions

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -567,13 +567,21 @@ const Toaster = (props: ToasterProps) => {
 
     if (typeof window === 'undefined') return;
 
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', ({ matches }) => {
+    const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = ({ matches }: MediaQueryListEvent) => {
       if (matches) {
         setActualTheme('dark');
       } else {
         setActualTheme('light');
       }
-    });
+    };
+
+    if ('addEventListener' in mediaQueryList) {
+      mediaQueryList.addEventListener('change', handleChange);
+    } else {
+      // @ts-expect-error: Deprecated API
+      mediaQueryList.addListener(handleChange);
+    }
   }, [theme]);
 
   React.useEffect(() => {


### PR DESCRIPTION
### Issue:

Closes https://github.com/emilkowalski/sonner/issues/395

### What has been done:

- Added support for older Safari versions which doesn't have the `addEventListener` method.

I didn't add a test but you can check [this](https://stackoverflow.com/questions/56466261/matchmedia-addlistener-marked-as-deprecated-addeventlistener-equivalent) SO post for reference.
