### PR TITLE
Pause timer if toast appears when the document is hidden

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const useIsDocumentHidden = () => {
-  const [isDocumentHidden, setIsDocumentHidden] = React.useState(false);
+  const [isDocumentHidden, setIsDocumentHidden] = React.useState(document.hidden);
 
   React.useEffect(() => {
     const callback = () => {


### PR DESCRIPTION
### Issue:

The flag `pauseWhenPageIsHidden` works fine when you are on the page -> toast appears -> you switch to another tab = timers paused. But when the tab with your app is in the background and you render your toasts(e.g. through WebSockets) timers don't pause.

### What has been done:

- [x] add a default value for the useIsDocumentHidden hook

