### PR TITLE
chore(docs): include a section about persisting toasts

### DIFF
--- a/website/src/pages/toast.mdx
+++ b/website/src/pages/toast.mdx
@@ -178,6 +178,16 @@ toast('Event has been created', {
 });
 ```
 
+### Persisting toasts
+
+If you want a toast to stay on screen forever, you can set the `duration` to [`Infinity`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity).
+
+```js
+toast('This toast will stay on screen forever', {
+  duration: Infinity,
+});
+```
+
 ### Dismissing toasts programmatically
 
 To remove a toast programmatically use `toast.dismiss(id)`. The `toast()` function return the id of the toast.


### PR DESCRIPTION
### Issue:

It seems the section about "persistent toast" in this [PR](https://github.com/emilkowalski/sonner/pull/46/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) didn't make it to the new docs. 

Closes https://github.com/emilkowalski/sonner/issues/429 

### What has been done:

- Update the `toast.mdx` to include a few lines about how to make a toast persist forever

