### PR TITLE
Allow dismissing toasts with id = 0

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -70,7 +70,7 @@ class Observer {
   };
 
   dismiss = (id?: number | string) => {
-    if (!id) {
+    if (typeof id !== undefined && id !== '') {
       this.toasts.forEach((toast) => {
         this.subscribers.forEach((subscriber) => subscriber({ id: toast.id, dismiss: true }));
       });


### PR DESCRIPTION
This PR fixes a bug when you can't dismiss a toast with id = 0