### PR TITLE
Include styles.css in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.tsx",
+    "build": "tsup src/index.tsx && cp src/styles.css dist/styles.css",
     "dev": "tsup src/index.tsx --watch",
     "dev:website": "turbo run dev --filter=website...",
     "dev:test": "turbo run dev --filter=test...",


### PR DESCRIPTION
### Issue:

Related-to https://github.com/emilkowalski/sonner/issues/386

Granted, this should be seen as a workaround, since the css is already bundled in the js. The root cause of Remix's spotty support for sonner is unclear, but referencing the css directly works for me:

```typescript
import sonnerStyles from 'sonner/dist/styles.css?url'

export const links: LinksFunction = () => [
    { rel: 'stylesheet', href: sonnerStyles },
]
```

### What has been done:

- [x] Copy the styles.css into the dist folder so it can be referenced by consumers as `sonner/dist/styles.css`

### Screenshots/Videos:

N/A
