### PR TITLE
fix: add "main" entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/index.mjs",
     "require": "./dist/index.js"
   },
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
### Issue:

Closes https://github.com/emilkowalski/sonner/issues/456

### What has been done:

- [x] Adds "main" entry in package.json

According to [Node.js documentation](https://nodejs.org/api/packages.html#package-entry-points) only on older versions of Node.js should `main` be required.

> For new packages targeting the currently supported versions of Node.js, the ["exports"](https://nodejs.org/api/packages.html#exports) field is recommended. For packages supporting Node.js 10 and below, the ["main"](https://nodejs.org/api/packages.html#main) field is required. If both ["exports"](https://nodejs.org/api/packages.html#exports) and ["main"](https://nodejs.org/api/packages.html#main) are defined, the ["exports"](https://nodejs.org/api/packages.html#exports) field takes precedence over ["main"](https://nodejs.org/api/packages.html#main) in supported versions of Node.js.

~Regardless, Parcel doesn't seem to honor the sole existence of `exports` (without `main`). This change will support both by allowing `exports` to take precedence per the above.~

UPDATE: Seems like the issue could be due to [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) not [supported in Parcel](https://github.com/parcel-bundler/parcel/issues/8221#issuecomment-1159092245). I think this is good justification to add the `main` entry as a fallback for when conditional exports is not supported (like in the case of Parcel).
