### PR TITLE
fix: missing exported types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -747,3 +747,4 @@ const Toaster = (props: ToasterProps) => {
   );
 };
 export { toast, Toaster, type ExternalToast, type ToastT, type ToasterProps, useSonner };
+export { type ToastClassnames, type ToastToDismiss, type Action } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface ToastIcons {
   loading?: React.ReactNode;
 }
 
-interface Action {
+export interface Action {
   label: React.ReactNode;
   onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   actionButtonStyle?: React.CSSProperties;


### PR DESCRIPTION
### Issue:

Closes https://github.com/emilkowalski/sonner/issues/455

### What has been done:

Added these exports from `src/index.tsx`:
```tsx
export { type ToastClassnames, type ToastToDismiss, type Action } from './types';
```

And the interface `Action` is now exported from `src/types.ts`
```tsx
export interface Action { .. }
```

### Validation

The issue reported in #455 is now resolved for me.