### PR TITLE
Allow awaiting `toast.promise`

### DIFF
--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { toast } from 'sonner';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
@@ -26,6 +27,17 @@ test.describe('Basic functionality', () => {
     await page.getByTestId('promise').click();
     await expect(page.getByText('Loading...')).toHaveCount(1);
     await expect(page.getByText('Loaded')).toHaveCount(1);
+  });
+
+  test('handle toast promise rejections', async ({ page }) => {
+    const rejectedPromise = new Promise((_, reject) => setTimeout(() => reject(new Error('Promise rejected')), 100));
+    try {
+      toast.promise(rejectedPromise, {});
+    } catch {
+      throw new Error('Promise should not have rejected without unwrap');
+    }
+
+    await expect(toast.promise(rejectedPromise, {}).unwrap()).rejects.toThrow('Promise rejected');
   });
 
   test('render custom jsx in toast', async ({ page }) => {


### PR DESCRIPTION
### Issue:

Closes https://github.com/emilkowalski/sonner/issues/339

### What has been done:

`toast.promise` now returns an `unwrap` method. This method returns a new promise that resolves or rejects when the provided promise does. Made sure to do this in a non-breaking way:
- The `id` is still returned.
- If the provided promise rejects, it will only reject when using `unwrap`. (see `basic.spec` for a test on that)

```ts
const result = await toast
  .promise(myPromise, { success: "Loaded", error: "Error" })
  .unwrap();

// `result` is now the resolved value of `myPromise`. In order to get the `id` we
// just have to use it like before

const id = toast.promise(myPromise, { success: "Loaded", error: "Error" }); // id = 3
const result = await id.unwrap(); // result = `myPromise` resolved value
```

### Screenshots/Videos:

N/A
