### PR TITLE
update/exports - metro compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,14 @@
   "version": "1.5.0",
   "description": "An opinionated toast component for React.",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    ".": [
+      {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js"
+      },
+      "./dist/index.js"
+    ]
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
### Issue:
- #474 

```
Metro error: Metro has encountered an error: While trying to resolve module `sonner` from file
````


### What has been done:

- [x] Update package.json for metro compatibility (for use in expo project)
  - updated the `node_modules` sonner directory package.json with the updates here and that works for my current Expo sdk 51 project in being able to use the latest version `1.5.0` of sonner.

### Screenshots/Videos:

N/A
