### PR TITLE
Fix inability to prevent toast from closing on action button click

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -432,8 +432,8 @@ const Toast = (props: ToastProps) => {
               onClick={(event) => {
                 // We need to check twice because typescript
                 if (!isAction(toast.action)) return;
-                if (event.defaultPrevented) return;
                 toast.action.onClick?.(event);
+                if (event.defaultPrevented) return;
                 deleteToast();
               }}
               className={cn(classNames?.actionButton, toast?.classNames?.actionButton)}


### PR DESCRIPTION
### Issue:

Closes https://github.com/emilkowalski/sonner/issues/172#issuecomment-2261611845

This PR restores the ability to prevent a toast from closing when action button is clicked by using `event.preventDefault()` in the `onClick` callback.

The current behavior does not honor `onClick`'s `event.preventDefault()`, which was unintentionally broken by https://github.com/emilkowalski/sonner/commit/7d28d42b368fd65f02d1d903c673111f3a430701.

The intended behavior is stated in the [documentation](https://sonner.emilkowal.ski/toast#action):
> You can prevent the toast from closing by calling `event.preventDefault()` in the `onClick` callback.

### What has been done:

- [x] Moved `onClick` call before the `defaultPrevented` check

### Screenshots/Videos:

N/A