### PR TITLE
fix: allow React.js v19 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "typescript": "^4.8.4"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+    "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
   },
   "packageManager": "pnpm@8.12.1"
 }


### PR DESCRIPTION
### What has been done:

Similarly to how it's done in `radix-ui/primitives`, we can allow React.js v19 in peerDependencies, as this library should pretty much be compatible with v19.

https://github.com/radix-ui/primitives/blob/74b182b401c8ca0fa5b66a5a9a47f507bb3d5adc/packages/react/collection/package.json#L39-L40

### Screenshots/Videos:

N/A
