### PR TITLE
fix: styles.css is not declared in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "1.6.1",
   "description": "An opinionated toast component for React.",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./dist/styles.css": "./dist/styles.css"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
In some cases, using `import 'sonner/dist/styles.css'` to import may cause Vite build errors.

see: https://github.com/vitejs/vite/discussions/2657

Reproduce the demo:
 [https://github.com/molvqingtai/wxt-import-css-report](https://github.com/molvqingtai/wxt-import-css-report)