### PR TITLE
fix: prevent double custom toast counter increase when initial id is undefined

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -186,7 +186,7 @@ class Observer {
 
   custom = (jsx: (id: number | string) => React.ReactElement, data?: ExternalToast) => {
     const id = data?.id || toastsCounter++;
-    this.create({ jsx: jsx(id), id, ...data });
+    this.create({ jsx: jsx(id), ...data, id });
     return id;
   };
 }

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -107,6 +107,28 @@ export default function Home({ searchParams }: any) {
         Render Custom Toast
       </button>
       <button
+        data-testid="update-custom-toast"
+        className="button"
+        onClick={() => {
+          const toastId = toast.custom((t) => (
+            <div>
+              My custom toast - unupdated
+            </div>
+          ), {
+            id: undefined
+          })
+          toast.custom((t) => (
+            <div>
+              My custom toast - updated
+            </div>
+          ), {
+            id: toastId
+          })
+        }}
+      >
+        Update Custom Toast
+      </button>
+      <button
         data-testid="custom-cancel-button-toast"
         className="button"
         onClick={() =>

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -178,6 +178,12 @@ test.describe('Basic functionality', () => {
     await expect(page.getByText('My Updated Toast')).toHaveCount(1);
   });
 
+  test('show correct toast content when updating custom toast', async ({ page }) => {
+    await page.getByTestId('update-custom-toast').click();
+    await expect(page.getByText('My custom toast - unupdated')).toHaveCount(0);
+    await expect(page.getByText('My custom toast - updated')).toHaveCount(1);
+  });
+
   test('cancel button is rendered with custom styles', async ({ page }) => {
     await page.getByTestId('custom-cancel-button-toast').click();
     const button = await page.locator('[data-cancel]');


### PR DESCRIPTION
## Problem:
When creating a custom wrapper around Sonner `custom` toast i have encountered an issue with toast updating.  
Despite providing proper id to the second invocation, second toast was created, instead of an update to the existing one.

After skimming trough the code, i have noticed that the generated `id` was overwritten in case of `id: undefined`.
In that case `toastsCounter` was increased again inside `create`, despite originally created id being returned from the function, creating id mismatch.

## Fix:
Changed the parameter order when calling `create` from `custom`, so generated id would not be overwritten by `data.id` being set to `undefined`.

Also added regression test.
