### PR TITLE
Fix top position swipe direction

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -320,15 +320,15 @@ const Toast = (props: ToastProps) => {
 
         const yPosition = event.clientY - pointerStartRef.current.y;
         const isHighlighted = window.getSelection()?.toString().length > 0;
-        const swipeAmount = Number(toastRef.current?.style.getPropertyValue('--swipe-amount').replace('px', '') || 0);
+        const swipeAmount = y === 'top' ? Math.min(0, yPosition) : Math.max(0, yPosition);
 
-        if (swipeAmount > 0) {
+        if (Math.abs(swipeAmount) > 0) {
           setIsSwiped(true);
         }
 
         if (isHighlighted) return;
 
-        toastRef.current?.style.setProperty('--swipe-amount', `${Math.max(0, yPosition)}px`);
+        toastRef.current?.style.setProperty('--swipe-amount', `${swipeAmount}px`);
       }}
     >
       {closeButton && !toast.jsx ? (


### PR DESCRIPTION
### 🎫 Issue:
Closes https://github.com/emilkowalski/sonner/issues/512

### 🗒️ Proposed Fix:

- Change `swipeAmount` to check if `y` is `top` which makes top-positioned toasts only able to be swiped upward (negative values) and bottom-positioned toasts only able to be swiped downward (positive values).