### PR TITLE
chore: Hide the close button when toastType is loading

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -331,7 +331,7 @@ const Toast = (props: ToastProps) => {
         toastRef.current?.style.setProperty('--swipe-amount', `${swipeAmount}px`);
       }}
     >
-      {closeButton && !toast.jsx ? (
+      {closeButton && !toast.jsx && toastType !== 'loading' ? (
         <button
           aria-label={closeButtonAriaLabel}
           data-disabled={disabled}


### PR DESCRIPTION
## Background
If the toast is closed while `toastType` is `loading`, the user will not be able to see the completed result.

Therefore, it seems that `toastType` is prevented from closing when it is `loading`.

However, since there are two issues related to this, to avoid any misunderstanding, it might be better not to render the close button when the `toastType` is `loading`.

Therefore, I am submitting a pull request to ensure that the close button is not rendered when `toastType` is `loading`.

## Reference
#514 #476