### PR TITLE
fix: hydration warning

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -653,6 +653,7 @@ const Toaster = forwardRef<HTMLElement, ToasterProps>(function Toaster(props, re
       aria-live="polite"
       aria-relevant="additions text"
       aria-atomic="false"
+      suppressHydrationWarning
     >
       {possiblePositions.map((position, index) => {
         const [y, x] = position.split('-');


### PR DESCRIPTION
For cases where `<Toaster />` is accidentally added to `<html>` instead of `<body>`