### PR TITLE
Enhance Promise to support ExternalToast propertiesfeat: Promise enhancement to allow ExternalToast props

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,12 @@
-import type { ExternalToast, PromiseData, PromiseT, ToastT, ToastToDismiss, ToastTypes } from './types';
+import type {
+  ExternalToast,
+  PromiseData,
+  PromiseIExtendedResult,
+  PromiseT,
+  ToastT,
+  ToastToDismiss,
+  ToastTypes,
+} from './types';
 
 import React from 'react';
 
@@ -137,28 +145,40 @@ class Observer {
           this.create({ id, type: 'default', message: response });
         } else if (isHttpResponse(response) && !response.ok) {
           shouldDismiss = false;
-          const message =
+          const promiseData =
             typeof data.error === 'function' ? await data.error(`HTTP error! status: ${response.status}`) : data.error;
           const description =
             typeof data.description === 'function'
               ? await data.description(`HTTP error! status: ${response.status}`)
               : data.description;
-          this.create({ id, type: 'error', message, description });
+
+          const toastSettings: PromiseIExtendedResult =
+            typeof promiseData === 'object' ? (promiseData as PromiseIExtendedResult) : { message: promiseData };
+
+          this.create({ id, type: 'error', description, ...toastSettings });
         } else if (data.success !== undefined) {
           shouldDismiss = false;
-          const message = typeof data.success === 'function' ? await data.success(response) : data.success;
+          const promiseData = typeof data.success === 'function' ? await data.success(response) : data.success;
           const description =
             typeof data.description === 'function' ? await data.description(response) : data.description;
-          this.create({ id, type: 'success', message, description });
+
+          const toastSettings: PromiseIExtendedResult =
+            typeof promiseData === 'object' ? (promiseData as PromiseIExtendedResult) : { message: promiseData };
+
+          this.create({ id, type: 'success', description, ...toastSettings });
         }
       })
       .catch(async (error) => {
         result = ['reject', error];
         if (data.error !== undefined) {
           shouldDismiss = false;
-          const message = typeof data.error === 'function' ? await data.error(error) : data.error;
+          const promiseData = typeof data.error === 'function' ? await data.error(error) : data.error;
           const description = typeof data.description === 'function' ? await data.description(error) : data.description;
-          this.create({ id, type: 'error', message, description });
+
+          const toastSettings: PromiseIExtendedResult =
+            typeof promiseData === 'object' ? (promiseData as PromiseIExtendedResult) : { message: promiseData };
+
+          this.create({ id, type: 'error', description, ...toastSettings });
         }
       })
       .finally(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,14 @@ export type ToastTypes = 'normal' | 'action' | 'success' | 'info' | 'warning' | 
 
 export type PromiseT<Data = any> = Promise<Data> | (() => Promise<Data>);
 
+export interface PromiseIExtendedResult extends ExternalToast {
+  message: React.ReactNode;
+}
+
+export type PromiseTExtendedResult<Data = any> =
+  | PromiseIExtendedResult
+  | ((data: Data) => PromiseIExtendedResult | Promise<PromiseIExtendedResult>);
+
 export type PromiseTResult<Data = any> =
   | string
   | React.ReactNode
@@ -13,8 +21,8 @@ export type PromiseExternalToast = Omit<ExternalToast, 'description'>;
 
 export type PromiseData<ToastData = any> = PromiseExternalToast & {
   loading?: string | React.ReactNode;
-  success?: PromiseTResult<ToastData>;
-  error?: PromiseTResult;
+  success?: PromiseTResult<ToastData> | PromiseTExtendedResult<ToastData>;
+  error?: PromiseTResult | PromiseTExtendedResult;
   description?: PromiseTResult;
   finally?: () => void | Promise<void>;
 };


### PR DESCRIPTION
Resolves #464

Introduce new types and extend existing functionality to allow for more detailed toast messages in promise handling. This enhancement improves the flexibility of toast notifications by incorporating additional properties.

Usage:
```
toast.promise<{ name: string }>(
  () =>
    new Promise((resolve, reject) => {
      setTimeout(() => {
        resolve({ name: 'Sonner' });
      }, 2000);
    }),
  {
    loading: 'Loading...',
    success: (data) => {
      return {
        message: `${data.name} toast has been added`,
        description: 'Custom description for the Success state',
      };
    },
    error: {
      message: 'An error occurred',
      description: undefined, // overrides default description set below
      action: {
        label: 'Retry',
        onClick: () => {
          console.log('retrying');
        },
      },
    },
    description: 'Global description',
  },
)
```

This is a non-breaking change, so you can still pass values as defined in the docs:
```
toast.promise<{ name: string }>(
  () =>
    new Promise((resolve, reject) => {
      setTimeout(() => {
        resolve({ name: 'Sonner' });
      }, 2000);
    }),
  {
    loading: 'Loading...',
    success: (data) => {
      return `${data.name} toast has been added`;
    },
    error: 'Error',
    description: 'Global description',
  },
)
```