### PR TITLE
fix: swallowed mouseUp event

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ jobs:
       - run: pnpm build
       - run: npx playwright install --with-deps
       - run: pnpm test || exit 1
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -406,7 +406,6 @@ const Toast = (props: ToastProps) => {
         toastRef.current?.style.setProperty('--swipe-amount-y', `${swipeAmount.y}px`);
       }}
     >
-      <a href="/">link</a>
       {closeButton && !toast.jsx ? (
         <button
           aria-label={closeButtonAriaLabel}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -309,6 +309,11 @@ const Toast = (props: ToastProps) => {
           ...toast.style,
         } as React.CSSProperties
       }
+      onDragEnd={() => {
+        setSwiping(false);
+        setSwipeDirection(null);
+        pointerStartRef.current = null;
+      }}
       onPointerDown={(event) => {
         if (disabled || !dismissible) return;
         dragStartTime.current = new Date();
@@ -401,6 +406,7 @@ const Toast = (props: ToastProps) => {
         toastRef.current?.style.setProperty('--swipe-amount-y', `${swipeAmount.y}px`);
       }}
     >
+      <a href="/">link</a>
       {closeButton && !toast.jsx ? (
         <button
           aria-label={closeButtonAriaLabel}
@@ -821,6 +827,7 @@ const Toaster = forwardRef<HTMLElement, ToasterProps>(function Toaster(props, re
                 setExpanded(false);
               }
             }}
+            onDragEnd={() => setExpanded(false)}
             onPointerDown={(event) => {
               const isNotDismissible =
                 event.target instanceof HTMLElement && event.target.dataset.dismissible === 'false';


### PR DESCRIPTION
The mouseUp event can be swallowed by e.g. a link in the toast and then the toast will follow the mouse around and never go away as it still think its being dragged.