### PR TITLE
Add initial lift translation as a prop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,9 @@ const TOAST_WIDTH = 356;
 // Default gap between toasts
 const GAP = 14;
 
+// Default initial lift for expanding toasts on hover
+const LIFT = -8;
+
 // Threshold to dismiss a toast
 const SWIPE_THRESHOLD = 45;
 
@@ -600,6 +603,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
     toastOptions,
     dir = getDocumentDirection(),
     gap = GAP,
+    initialLift = LIFT,
     icons,
     containerAriaLabel = 'Notifications',
   } = props;
@@ -788,6 +792,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
                 '--front-toast-height': `${heights[0]?.height || 0}px`,
                 '--width': `${TOAST_WIDTH}px`,
                 '--gap': `${gap}px`,
+                '--initial-lift': `${initialLift}px`,
                 ...style,
                 ...assignOffset(offset, mobileOffset),
               } as React.CSSProperties

--- a/src/styles.css
+++ b/src/styles.css
@@ -52,7 +52,7 @@ html[dir='rtl'],
 }
 
 [data-sonner-toaster][data-lifted='true'] {
-  transform: translateY(-8px);
+  transform: translateY(var(--initial-lift));
 }
 
 @media (hover: none) and (pointer: coarse) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,7 @@ export interface ToasterProps {
   expand?: boolean;
   duration?: number;
   gap?: number;
+  initialLift?: number;
   visibleToasts?: number;
   closeButton?: boolean;
   toastOptions?: ToastOptions;


### PR DESCRIPTION
## Summary

* Replaced -8px initial lifted value with css variable
* Added default LIFT value using -8px
* Added --initial-lift variable set in styles
* Added initialLift to ToasterProps

### Reason

Adding this because I noticed in latets version that on computer my mouse can trigger a loop when it hovers at the bottom of a toast container. 

This will cause the toasts to expand, lift up above where mouse is hovering, lose focus, collapse, and repeat.

I wasn't exactly sure why the initial lift value was hardcoded, so rather than remove it, just added a way to set that value (in my case to 0).

#### Guidance

I don't contribute to a lot of OSS, so if there anything minor that's wrong with this, please feel free to let me know.