### PR TITLE
feat: inherit color for description when rich colors is `true`

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -134,6 +134,10 @@ html[dir='rtl'],
   color: #3f3f3f;
 }
 
+[data-rich-colors='true'][data-sonner-toast][data-styled='true'] [data-description] {
+  color: inherit;
+}
+
 [data-sonner-toaster][data-sonner-theme='dark'] [data-description] {
   color: hsl(0, 0%, 91%);
 }


### PR DESCRIPTION
<img width="411" alt="image" src="https://github.com/user-attachments/assets/7f0d09ec-f5ee-4c66-94aa-9256fe849c45" />
