### PR TITLE
Subscribe to state changes earlier, with `useLayoutEffect`

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+export const safeUseLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : () => {};
+
 export const useIsDocumentHidden = () => {
   const [isDocumentHidden, setIsDocumentHidden] = React.useState(document.hidden);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { CloseIcon, getAsset, Loader } from './assets';
-import { useIsDocumentHidden } from './hooks';
+import { safeUseLayoutEffect, useIsDocumentHidden } from './hooks';
 import { toast, ToastState } from './state';
 import './styles.css';
 import {
@@ -548,8 +548,8 @@ function assignOffset(defaultOffset: ToasterProps['offset'], mobileOffset: Toast
 function useSonner() {
   const [activeToasts, setActiveToasts] = React.useState<ToastT[]>([]);
 
-  React.useEffect(() => {
     return ToastState.subscribe((toast) => {
+  safeUseLayoutEffect(() => {
       if ((toast as ToastToDismiss).dismiss) {
         setTimeout(() => {
           ReactDOM.flushSync(() => {
@@ -641,8 +641,8 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
     });
   }, []);
 
-  React.useEffect(() => {
     return ToastState.subscribe((toast) => {
+  safeUseLayoutEffect(() => {
       if ((toast as ToastToDismiss).dismiss) {
         // Prevent batching of other state updates
         requestAnimationFrame(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -690,7 +690,6 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
       }
     }
 
-    if (typeof window === 'undefined') return;
     const darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
     try {


### PR DESCRIPTION
Thanks for the great library!

I wanted to show an error toast using `toast.error()` from inside a `useLayoutEffect`, but it didn't work.

This fixes that 🎉 

So now providing the `useLayoutEffect` is from a component rendered after `<Sonner />` it should work, and this also means that using `useEffect` anywhere should always work regardless of whether `<Sonner />` is before or after the component using the hook.

Related #168

I also spotted a few race conditions so added some fixes for those in here too