### PR TITLE
chore: upgrade pnpm to v9 to fix lockfileVersion mismatch

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - run: npm install pnpm@8.12.1 -g
+      - run: npm install pnpm@9.15.9 -g
       - run: pnpm install --no-frozen-lockfile
       - run: pnpm build
       - run: npx playwright install --with-deps

--- a/package.json
+++ b/package.json
@@ -62,5 +62,5 @@
     "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
     "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
   },
-  "packageManager": "pnpm@8.12.1"
+  "packageManager": "pnpm@9.15.9"
 }


### PR DESCRIPTION
### Issue
Current `package.json` specifies `pnpm@8.12.1` but `pnpm-lock.yaml` has `lockfileVersion: '9.0'`. This version mismatch causes unintended lockfile changes when developers run `pnpm install` after cloning the repository.

- pnpm v8 automatically converts lockfileVersion to `6.0`
- lockfileVersion `9.0` was adopted in pnpm v9.0.0+

reference: [pnpm v9.0.0 release](https://github.com/pnpm/pnpm/releases/tag/v9.0.0)

### What has been done
- Upgraded `packageManager` from `pnpm@8.12.1` to `pnpm@9.15.9`
- Chose `9.15.9` as a latest release in the v9 series

### Screenshots/Videos
Unintended changes in `pnpm-lock.yaml` after running `pnpm install` on a git clone.
![image](https://github.com/user-attachments/assets/ca1c1a95-4458-4238-97a3-cd7472b61dc2)
