### PR TITLE
feat: add nonce support for style injection and update package to son…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ https://github.com/vallezw/sonner/assets/50796600/59b95cb7-9068-4f3e-8469-0b35d9
 To start using the library, install it in your project:
 
 ```bash
-npm install sonner
+npm install sonner-nonce  
 ```
 
 Add `<Toaster />` to your app, it will be the place where all your toasts will be rendered.
 After that you can use `toast()` from anywhere in your app.
 
 ```jsx
-import { Toaster, toast } from 'sonner';
+import { Toaster, toast } from 'sonner-nonce';
 
 // ...
 
@@ -28,6 +28,55 @@ function App() {
 }
 ```
 
+## Content Security Policy (CSP) Support
+
+If you're using Content Security Policy and need to add a nonce to the injected styles, you can pass a `nonce` prop to the `<Toaster />` component:
+
+```jsx
+import { Toaster, toast } from 'sonner-nonce';
+
+function App() {
+  return (
+    <div>
+      <Toaster nonce="your-csp-nonce-here" />
+      <button onClick={() => toast('My first toast')}>Give me a toast</button>
+    </div>
+  );
+}
+```
+
 ## Documentation
 
 Find the full API reference in the [documentation](https://sonner.emilkowal.ski/getting-started).
+
+---
+
+## Changes Applied in This Fork
+
+This fork adds Content Security Policy (CSP) nonce support to the original Sonner toast library. Here are the exact changes made:
+
+### New Files Created:
+- **`src/styles.ts`** - Contains CSS as a string constant and utility functions for style injection with nonce support
+
+### Files Modified:
+
+#### `src/types.ts`
+- Added `nonce?: string` to the `ToasterProps` interface
+
+#### `src/index.tsx`
+- Replaced `import './styles.css'` with `import { injectStyles } from './styles'`
+- Added `nonce` prop to Toaster component destructuring
+- Added `useEffect` hook to inject styles with nonce when component mounts
+
+#### `test/src/app/page.tsx`
+- Added test button for nonce functionality
+- Added `nonce="test-nonce-value"` prop to Toaster component
+
+#### `test/tests/basic.spec.ts`
+- Added test case `'nonce is applied to injected styles'` to verify nonce functionality
+
+### New Exported Functions:
+None - all functionality is handled automatically through the `nonce` prop
+
+### Breaking Changes:
+None - this fork maintains full backward compatibility with the original Sonner library.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ https://github.com/vallezw/sonner/assets/50796600/59b95cb7-9068-4f3e-8469-0b35d9
 To start using the library, install it in your project:
 
 ```bash
-npm install sonner-nonce  
+npm install sonner  
 ```
 
 Add `<Toaster />` to your app, it will be the place where all your toasts will be rendered.
 After that you can use `toast()` from anywhere in your app.
 
 ```jsx
-import { Toaster, toast } from 'sonner-nonce';
+import { Toaster, toast } from 'sonner';
 
 // ...
 
@@ -33,7 +33,7 @@ function App() {
 If you're using Content Security Policy and need to add a nonce to the injected styles, you can pass a `nonce` prop to the `<Toaster />` component:
 
 ```jsx
-import { Toaster, toast } from 'sonner-nonce';
+import { Toaster, toast } from 'sonner';
 
 function App() {
   return (

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sonner-nonce",
+  "name": "sonner",
   "version": "2.0.6",
   "description": "An opinionated toast component for React.",
   "exports": {
@@ -13,7 +13,8 @@
         "default": "./dist/index.js"
       },
       "default": "./dist/index.js"
-    }
+    },
+    "./dist/styles.css": "./dist/styles.css"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -22,7 +23,7 @@
   ],
   "scripts": {
     "dev": "bunchee --watch",
-    "build": "bunchee",
+    "build": "bunchee && cp src/styles.css dist/styles.css",
     "type-check": "tsc --noEmit",
     "dev:website": "turbo run dev --filter=website...",
     "dev:test": "turbo run dev --filter=test...",
@@ -41,10 +42,10 @@
   "homepage": "https://sonner.emilkowal.ski/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supafox/sonner-nonce.git"
+    "url": "git+https://github.com/emilkowalski/sonner.git"
   },
   "bugs": {
-    "url": "https://github.com/supafox/sonner-nonce/issues"
+    "url": "https://github.com/emilkowalski/sonner/issues"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sonner",
+  "name": "sonner-nonce",
   "version": "2.0.6",
   "description": "An opinionated toast component for React.",
   "exports": {
@@ -13,8 +13,7 @@
         "default": "./dist/index.js"
       },
       "default": "./dist/index.js"
-    },
-    "./dist/styles.css": "./dist/styles.css"
+    }
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -23,7 +22,7 @@
   ],
   "scripts": {
     "dev": "bunchee --watch",
-    "build": "bunchee && cp src/styles.css dist/styles.css",
+    "build": "bunchee",
     "type-check": "tsc --noEmit",
     "dev:website": "turbo run dev --filter=website...",
     "dev:test": "turbo run dev --filter=test...",
@@ -42,10 +41,10 @@
   "homepage": "https://sonner.emilkowal.ski/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/emilkowalski/sonner.git"
+    "url": "git+https://github.com/supafox/sonner-nonce.git"
   },
   "bugs": {
-    "url": "https://github.com/emilkowalski/sonner/issues"
+    "url": "https://github.com/supafox/sonner-nonce/issues"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import ReactDOM from 'react-dom';
 import { CloseIcon, getAsset, Loader } from './assets';
 import { useIsDocumentHidden } from './hooks';
 import { toast, ToastState } from './state';
-import './styles.css';
+import { injectStyles } from './styles';
 import {
   isAction,
   SwipeDirection,
@@ -609,6 +609,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
     gap = GAP,
     icons,
     containerAriaLabel = 'Notifications',
+    nonce,
   } = props;
   const [toasts, setToasts] = React.useState<ToastT[]>([]);
   const possiblePositions = React.useMemo(() => {
@@ -675,6 +676,11 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
       });
     });
   }, [toasts]);
+
+  // Inject styles with nonce if provided
+  React.useEffect(() => {
+    injectStyles(nonce);
+  }, [nonce]);
 
   React.useEffect(() => {
     if (theme !== 'system') {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,3 +1,5 @@
+// CSS content as a string to allow nonce injection
+export const CSS_CONTENT = `
 html[dir='ltr'],
 [data-sonner-toaster][dir='ltr'] {
   --toast-icon-margin-start: -3px;
@@ -722,3 +724,22 @@ html[dir='rtl'],
   opacity: 0;
   transform: scale(0.8) translate(-50%, -50%);
 }
+`;
+
+// Function to inject CSS with optional nonce
+export function injectStyles(nonce?: string): void {
+  // Check if styles are already injected
+  if (document.querySelector('#sonner-styles')) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = 'sonner-styles';
+  style.textContent = CSS_CONTENT;
+  
+  if (nonce) {
+    style.setAttribute('nonce', nonce);
+  }
+  
+  document.head.appendChild(style);
+} 

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,6 +142,7 @@ export interface ToasterProps {
   swipeDirections?: SwipeDirection[];
   icons?: ToastIcons;
   containerAriaLabel?: string;
+  nonce?: string;
 }
 
 export type SwipeDirection = 'top' | 'right' | 'bottom' | 'left';

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -313,6 +313,13 @@ export default function Home({ searchParams }: any) {
       >
         With custom ARIA labels
       </button>
+      <button
+        data-testid="nonce-example"
+        className="button"
+        onClick={() => toast('Toast with CSP nonce support')}
+      >
+        Toast with CSP Nonce Support
+      </button>
       {showAutoClose ? <div data-testid="auto-close-el" /> : null}
       {showDismiss ? <div data-testid="dismiss-el" /> : null}
       <Toaster
@@ -326,6 +333,7 @@ export default function Home({ searchParams }: any) {
         theme={theme}
         dir={searchParams.dir || 'auto'}
         containerAriaLabel={showAriaLabels ? 'Notices' : undefined}
+        nonce="test-nonce-value"
         icons={{
           close:
             searchParams.customCloseIcon === '' ? (

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -293,4 +293,15 @@ test.describe('Basic functionality', () => {
     await expect(page.getByLabel('Notices')).toHaveCount(1);
     await expect(page.getByLabel('Yeet the notice', { exact: true })).toHaveCount(1);
   });
+
+  test('nonce is applied to injected styles', async ({ page }) => {
+    await page.getByTestId('nonce-example').click();
+    
+    // Check that the style element has the nonce attribute
+    const styleElement = page.locator('#sonner-styles');
+    await expect(styleElement).toHaveAttribute('nonce', 'test-nonce-value');
+    
+    // Verify toast is rendered
+    await expect(page.getByText('Toast with CSP nonce support')).toHaveCount(1);
+  });
 });


### PR DESCRIPTION
## Changes Applied in This Fork

This fork adds Content Security Policy (CSP) nonce support to the original Sonner toast library. Here are the exact changes made:

### New Files Created:
- **`src/styles.ts`** - Contains CSS as a string constant and utility functions for style injection with nonce support

### Files Modified:

#### `src/types.ts`
- Added `nonce?: string` to the `ToasterProps` interface

#### `src/index.tsx`
- Replaced `import './styles.css'` with `import { injectStyles } from './styles'`
- Added `nonce` prop to Toaster component destructuring
- Added `useEffect` hook to inject styles with nonce when component mounts

#### `test/src/app/page.tsx`
- Added test button for nonce functionality
- Added `nonce="test-nonce-value"` prop to Toaster component

#### `test/tests/basic.spec.ts`
- Added test case `'nonce is applied to injected styles'` to verify nonce functionality

### New Exported Functions:
None - all functionality is handled automatically through the `nonce` prop

### Breaking Changes:
None - this fork maintains full backward compatibility with the original Sonner library.