### PR TITLE
fix: Prevent duplicate toasts with same text

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -54,18 +54,19 @@ class Observer {
   ) => {
     const { message, ...rest } = data;
     const id = typeof data?.id === 'number' || data.id?.length > 0 ? data.id : toastsCounter++;
-    const alreadyExists = this.toasts.find((toast) => {
-      return toast.id === id;
+    const existingToast = this.toasts.find((toast) => {
+      return toast.id === id || toastHasSameText(toast, message);
     });
+
     const dismissible = data.dismissible === undefined ? true : data.dismissible;
 
     if (this.dismissedToasts.has(id)) {
       this.dismissedToasts.delete(id);
     }
 
-    if (alreadyExists) {
+    if (existingToast) {
       this.toasts = this.toasts.map((toast) => {
-        if (toast.id === id) {
+        if (toast.id === existingToast.id) {
           this.publish({ ...toast, ...data, id, title: message });
           return {
             ...toast,
@@ -280,6 +281,8 @@ const basicToast = toastFunction;
 
 const getHistory = () => ToastState.toasts;
 const getToasts = () => ToastState.getActiveToasts();
+const toastHasSameText = (toast: ToastT | ToastToDismiss, message: titleT) =>
+  typeof message === 'string' && 'title' in toast && typeof toast.title === 'string' && message === toast.title;
 
 // We use `Object.assign` to maintain the correct types as we would lose them otherwise
 export const toast = Object.assign(

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -23,6 +23,12 @@ test.describe('Basic functionality', () => {
     await expect(page.locator('[data-button]')).toHaveCount(1);
   });
 
+  test('does not render duplicate toasts with the same text', async ({ page }) => {
+    await page.getByTestId('success').click();
+    await page.getByTestId('success').click();
+    await expect(page.getByText('My Success Toast', { exact: true })).toHaveCount(1);
+  });
+
   test('show correct toast content based on promise state', async ({ page }) => {
     await page.getByTestId('promise').click();
     await expect(page.getByText('Loading...')).toHaveCount(1);
@@ -265,14 +271,14 @@ test.describe('Basic functionality', () => {
 
   test('cancel button is rendered with custom styles', async ({ page }) => {
     await page.getByTestId('custom-cancel-button-toast').click();
-    const button = await page.locator('[data-cancel]');
+    const button = page.locator('[data-cancel]');
 
     await expect(button).toHaveCSS('background-color', 'rgb(254, 226, 226)');
   });
 
   test('action button is rendered with custom styles', async ({ page }) => {
     await page.getByTestId('action').click();
-    const button = await page.locator('[data-button]');
+    const button = page.locator('[data-button]');
 
     await expect(button).toHaveCSS('background-color', 'rgb(219, 239, 255)');
   });


### PR DESCRIPTION
This PR changes so that duplicate toasts with the exact same (string) text are not shown. 

While it could be opt in via a `preventDuplicate` option or similar,  I can't think of any use case where you would want to display multiple toasts with exact same message, so making this default like other libraries such as [notistack](https://notistack.com/) makes sense IMO.

Note: A more advanced solution could be implemented to also compare non-strings, but most toasts are string messages anyway so this is good enough IMO.