### PR TITLE
fix: description color in light theme

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -127,7 +127,7 @@ html[dir='rtl'],
 [data-sonner-toast][data-styled='true'] [data-description] {
   font-weight: 400;
   line-height: 1.4;
-  color: #3f3f3f;
+  color: inherit;
 }
 
 [data-rich-colors='true'][data-sonner-toast][data-styled='true'] [data-description] {


### PR DESCRIPTION
tiny bug in style for description showing up in light theme when using sonner with shadcn/ui.
<img width="846" height="143" alt="image" src="https://github.com/user-attachments/assets/42d7b35d-523c-4359-ad75-bf598b13f0fb" />
left is without the fix