### PR TITLE
Fixed handling when `hotkey` is an empty array

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -738,7 +738,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      const isHotkeyPressed = hotkey.every((key) => (event as any)[key] || event.code === key);
+      const isHotkeyPressed = hotkey.length > 0 && hotkey.every((key) => (event as any)[key] || event.code === key);
 
       if (isHotkeyPressed) {
         setExpanded(true);


### PR DESCRIPTION
The `every` method always returns `true` for an empty array. To get the correct result, you must also include the number of elements in the array as a condition before the `every` method.