### PR TITLE
feat: toaster transition duration option

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,6 +88,7 @@ const Toast = (props: ToastProps) => {
     classNames,
     icons,
     closeButtonAriaLabel = 'Close toast',
+    transitionDuration = 400,
   } = props;
   const [swipeDirection, setSwipeDirection] = React.useState<'x' | 'y' | null>(null);
   const [swipeOutDirection, setSwipeOutDirection] = React.useState<'left' | 'right' | 'up' | 'down' | null>(null);
@@ -291,6 +292,7 @@ const Toast = (props: ToastProps) => {
       data-swipe-direction={swipeOutDirection}
       data-expanded={Boolean(expanded || (expandByDefault && mounted))}
       data-testid={toast.testId}
+      data-transition-duration={transitionDuration}
       style={
         {
           '--index': index,
@@ -298,6 +300,7 @@ const Toast = (props: ToastProps) => {
           '--z-index': toasts.length - index,
           '--offset': `${removed ? offsetBeforeRemove : offset.current}px`,
           '--initial-height': expandByDefault ? 'auto' : `${initialHeight}px`,
+          '--transition-duration': `transform ${transitionDuration}ms, opacity ${transitionDuration}ms, height ${transitionDuration}ms, box-shadow ${transitionDuration}ms`,
           ...style,
           ...toast.style,
         } as React.CSSProperties
@@ -875,6 +878,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
                   gap={gap}
                   expanded={expanded}
                   swipeDirections={props.swipeDirections}
+                  transitionDuration={toastOptions?.transitionDuration}
                 />
               ))}
           </ol>

--- a/src/styles.css
+++ b/src/styles.css
@@ -86,7 +86,7 @@ html[dir='rtl'],
   opacity: 0;
   transform: var(--y);
   touch-action: none;
-  transition: transform 400ms, opacity 400ms, height 400ms, box-shadow 200ms;
+  transition: var(--transition-duration);
   box-sizing: border-box;
   outline: none;
   overflow-wrap: anywhere;

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,7 @@ interface ToastOptions {
   classNames?: ToastClassnames;
   closeButtonAriaLabel?: string;
   toasterId?: string;
+  transitionDuration?: number;
 }
 
 type Offset =
@@ -179,6 +180,7 @@ export interface ToastProps {
   icons?: ToastIcons;
   closeButtonAriaLabel?: string;
   defaultRichColors?: boolean;
+  transitionDuration?: number;
 }
 
 export enum SwipeStateTypes {


### PR DESCRIPTION
🚀 What's Changed
This PR introduces a new configuration option to the Toaster component, allowing users to control the speed of the transition animation.
- Added a transitionDuration property (Number in milliseconds) to the toastOptions object.
- This property dictates how long the toast's enter and exit animations (transitions) will last.

💡 Why This is Needed
As discussed in #690, the animation duration was previously fixed, which limited flexibility when integrating the component into different design systems.

This option resolves that by allowing developers to set the animation speed globally, ensuring the toast's appearance is perfectly synchronized with their application's UX flow—whether they need a lightning-fast notification or a leisurely slide-in.

🔧 How to Use
The duration can be set within the toastOptions when rendering the <Toaster /> component:

```js
<Toaster
  toastOptions={{
    // Set the transition duration to 400ms
    transitionDuration: 400,
  }}
/>
```
- Default: (State the current hardcoded default duration, e.g., 400ms)
- Unit: Milliseconds (ms)