### PR TITLE
Fix event listener removal in hooks.tsx

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -8,7 +8,7 @@ export const useIsDocumentHidden = () => {
       setIsDocumentHidden(document.hidden);
     };
     document.addEventListener('visibilitychange', callback);
-    return () => window.removeEventListener('visibilitychange', callback);
+    return () => document.removeEventListener('visibilitychange', callback);
   }, []);
 
   return isDocumentHidden;


### PR DESCRIPTION
This was causing event listeners to attach but no removal (clearance), resulting in too many event listeners.