### PR TITLE
Fix dismiss for custom toast

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -242,7 +242,7 @@ class Observer {
 
   custom = (jsx: (id: number | string) => React.ReactElement, data?: ExternalToast) => {
     const id = data?.id || toastsCounter++;
-    this.create({ jsx: jsx(id), id, ...data });
+    this.create({ jsx: jsx(id), ...data, id });
     return id;
   };
 

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -121,6 +121,27 @@ export default function Home({ searchParams }: any) {
       >
         Render Custom Cancel Button
       </button>
+      <button
+        data-testid="custom-with-empty-id"
+        className="button"
+        onClick={() =>
+          toast.custom(
+            (t) => (
+              <div>
+                <h1>jsx</h1>
+                <button data-testid="dismiss-button" onClick={() => toast.dismiss(t)}>
+                  Dismiss
+                </button>
+              </div>
+            ),
+            {
+              id: undefined,
+            },
+          )
+        }
+      >
+        Render Custom Toast with empty id
+      </button>
       <button data-testid="infinity-toast" className="button" onClick={() => toast('My Toast', { duration: Infinity })}>
         Render Infinity Toast
       </button>

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -270,6 +270,14 @@ test.describe('Basic functionality', () => {
     await expect(button).toHaveCSS('background-color', 'rgb(254, 226, 226)');
   });
 
+  test('cancel button dismisses the custom toast with empty id', async ({ page }) => {
+    await page.getByTestId('custom-with-empty-id').click();
+
+    await expect(page.locator('[data-sonner-toast]')).toHaveCount(1);
+    await page.locator('[data-dismiss]').click();
+    await expect(page.locator('[data-sonner-toast]')).toHaveCount(0);
+  });
+
   test('action button is rendered with custom styles', async ({ page }) => {
     await page.getByTestId('action').click();
     const button = await page.locator('[data-button]');


### PR DESCRIPTION
Fix the toast id when passing an empty id to a custom toast, as the internal id is computed twice.

If the id is empty, using `{ id, ...data }` always passes an empty id, and `toastsCounter++` is executed twice making the internal id wrong

Fixes #712 