### PR TITLE
feat: disable pause when page hidden prop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,6 +88,7 @@ const Toast = (props: ToastProps) => {
     classNames,
     icons,
     closeButtonAriaLabel = 'Close toast',
+    pauseWhenPageIsHidden: pauseWhenPageIsHiddenFromToaster = true,
   } = props;
   const [swipeDirection, setSwipeDirection] = React.useState<'x' | 'y' | null>(null);
   const [swipeOutDirection, setSwipeOutDirection] = React.useState<'left' | 'right' | 'up' | 'down' | null>(null);
@@ -137,6 +138,7 @@ const Toast = (props: ToastProps) => {
   }, [heights, heightIndex]);
   const isDocumentHidden = useIsDocumentHidden();
 
+  const pauseWhenPageIsHidden = toast.pauseWhenPageIsHidden ?? pauseWhenPageIsHiddenFromToaster;
   const invert = toast.invert || ToasterInvert;
   const disabled = toastType === 'loading';
 
@@ -225,14 +227,14 @@ const Toast = (props: ToastProps) => {
       }, remainingTime.current);
     };
 
-    if (expanded || interacting || isDocumentHidden) {
+    if (expanded || interacting || (pauseWhenPageIsHidden && isDocumentHidden)) {
       pauseTimer();
     } else {
       startTimer();
     }
 
     return () => clearTimeout(timeoutId);
-  }, [expanded, interacting, toast, toastType, isDocumentHidden, deleteToast]);
+  }, [expanded, interacting, toast, toastType, pauseWhenPageIsHidden, isDocumentHidden, deleteToast]);
 
   React.useEffect(() => {
     if (toast.delete) {
@@ -612,6 +614,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
     icons,
     customAriaLabel,
     containerAriaLabel = 'Notifications',
+    pauseWhenPageIsHidden = true,
   } = props;
   const [toasts, setToasts] = React.useState<ToastT[]>([]);
   const filteredToasts = React.useMemo(() => {
@@ -876,6 +879,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
                   gap={gap}
                   expanded={expanded}
                   swipeDirections={props.swipeDirections}
+                  pauseWhenPageIsHidden={pauseWhenPageIsHidden}
                 />
               ))}
           </ol>

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export interface ToastT {
   descriptionClassName?: string;
   position?: Position;
   testId?: string;
+  pauseWhenPageIsHidden?: boolean;
 }
 
 export function isAction(action: Action | React.ReactNode): action is Action {
@@ -147,6 +148,7 @@ export interface ToasterProps {
   icons?: ToastIcons;
   customAriaLabel?: string;
   containerAriaLabel?: string;
+  pauseWhenPageIsHidden?: boolean;
 }
 
 export type SwipeDirection = 'top' | 'right' | 'bottom' | 'left';
@@ -179,6 +181,7 @@ export interface ToastProps {
   icons?: ToastIcons;
   closeButtonAriaLabel?: string;
   defaultRichColors?: boolean;
+  pauseWhenPageIsHidden?: boolean;
 }
 
 export enum SwipeStateTypes {

--- a/website/src/pages/toaster.mdx
+++ b/website/src/pages/toaster.mdx
@@ -90,5 +90,5 @@ You can customize the default ARIA label for the notification container and the 
 | toastOptions          |               These will act as default options for all toasts. See [toast()](/toast) for all available options.                |         `4000` |
 | gap                   |                                                Gap between toasts when expanded                                                 |           `14` |
 | loadingIcon           |                                                Changes the default loading icon                                                 |            `-` |
-| pauseWhenPageIsHidden | Pauses toast timers when the page is hidden, e.g., when the tab is backgrounded, the browser is minimized, or the OS is locked. |        `false` |
+| pauseWhenPageIsHidden | Pauses toast timers when the page is hidden, e.g., when the tab is backgrounded, the browser is minimized, or the OS is locked. |        `true` |
 | icons                 |                                                    Changes the default icons                                                    |            `-` |


### PR DESCRIPTION
Adds a prop to control whether toast auto-dismiss timers pause when the page becomes hidden.

The name is verbose, but I used it as its already documented in [website/src/pages/toaster.mdx](https://github.com/ryoid/sonner/blob/eb36553b4cc77fb262552fa97218b3f373ec54d0/website/src/pages/toaster.mdx#L93)