### PR TITLE
feat: Add `enterFrom` prop to control toast entry direction (#671)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,6 +87,7 @@ const Toast = (props: ToastProps) => {
     expandByDefault,
     classNames,
     icons,
+    enterFrom,
     closeButtonAriaLabel = 'Close toast',
   } = props;
   const [swipeDirection, setSwipeDirection] = React.useState<'x' | 'y' | null>(null);
@@ -125,6 +126,9 @@ const Toast = (props: ToastProps) => {
   const lastCloseTimerStartTimeRef = React.useRef(0);
   const pointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
   const [y, x] = position.split('-');
+  // Per-toast > Toaster-level
+  const resolvedEnterFrom = toast.enterFrom ?? enterFrom;
+
   const toastsHeightBefore = React.useMemo(() => {
     return heights.reduce((prev, curr, reducerIndex) => {
       // Calculate offset up until current toast
@@ -281,6 +285,7 @@ const Toast = (props: ToastProps) => {
       data-visible={isVisible}
       data-y-position={y}
       data-x-position={x}
+      data-enter-from={resolvedEnterFrom}
       data-index={index}
       data-front={isFront}
       data-swiping={swiping}
@@ -612,6 +617,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
     icons,
     customAriaLabel,
     containerAriaLabel = 'Notifications',
+    enterFrom,
   } = props;
   const [toasts, setToasts] = React.useState<ToastT[]>([]);
   const filteredToasts = React.useMemo(() => {
@@ -770,6 +776,8 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
     }
   }, [listRef.current]);
 
+  const resolvedEnterFrom = enterFrom ?? toastOptions?.enterFrom;
+
   return (
     // Remove item from normal navigation flow, only available via hotkey
     <section
@@ -876,6 +884,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
                   gap={gap}
                   expanded={expanded}
                   swipeDirections={props.swipeDirections}
+                  enterFrom={resolvedEnterFrom}
                 />
               ))}
           </ol>

--- a/src/styles.css
+++ b/src/styles.css
@@ -84,7 +84,8 @@ html[dir='rtl'],
   z-index: var(--z-index);
   position: absolute;
   opacity: 0;
-  transform: var(--y);
+  --initial-x: 0px;
+  transform: translateX(var(--initial-x)) var(--y);
   touch-action: none;
   transition: transform 400ms, opacity 400ms, height 400ms, box-shadow 200ms;
   box-sizing: border-box;
@@ -122,6 +123,30 @@ html[dir='rtl'],
   --y: translateY(100%);
   --lift: -1;
   --lift-amount: calc(var(--lift) * var(--gap));
+}
+
+[data-sonner-toast][data-enter-from='left']:not([data-mounted='true']),
+[data-sonner-toast][data-enter-from='right']:not([data-mounted='true']) {
+  --y: translateY(0);
+}
+
+[data-sonner-toast][data-enter-from='left']:not([data-mounted='true']) {
+  --initial-x: -100%;
+}
+
+[data-sonner-toast][data-enter-from='right']:not([data-mounted='true']) {
+  --initial-x: 100%;
+}
+
+/* Vertical enterFrom, usando SwipeDirection: 'up' | 'down' */
+[data-sonner-toast][data-enter-from='top']:not([data-mounted='true']) {
+  /* entra sempre de cima, independente de top/bottom */
+  --y: translateY(-100%);
+}
+
+[data-sonner-toast][data-enter-from='bottom']:not([data-mounted='true']) {
+  /* entra sempre de baixo, independente de top/bottom */
+  --y: translateY(100%);
 }
 
 [data-sonner-toast][data-styled='true'] [data-description] {
@@ -287,6 +312,7 @@ html[dir='rtl'],
 
 [data-sonner-toast][data-mounted='true'] {
   --y: translateY(0);
+  --initial-x: 0px;
   opacity: 1;
 }
 
@@ -421,6 +447,20 @@ html[dir='rtl'],
     transform: var(--y) translateY(calc(var(--swipe-amount-y) + 100%));
     opacity: 0;
   }
+}
+
+[data-sonner-toast][data-enter-from='right'][data-front='true'][data-removed='true'] {
+  animation: none !important;
+  --y: translateY(0);
+  --initial-x: 100%;
+  transform: translateX(100%) translateY(0);
+}
+
+[data-sonner-toast][data-enter-from='left'][data-front='true'][data-removed='true'] {
+  animation: none !important;
+  --y: translateY(0);
+  --initial-x: -100%;
+  transform: translateX(-100%) translateY(0);
 }
 
 @media (max-width: 600px) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ export interface ToastT {
   classNames?: ToastClassnames;
   descriptionClassName?: string;
   position?: Position;
+  enterFrom?: EnterFromDirection;
   testId?: string;
 }
 
@@ -112,6 +113,7 @@ interface ToastOptions {
   unstyled?: boolean;
   classNames?: ToastClassnames;
   closeButtonAriaLabel?: string;
+  enterFrom?: EnterFromDirection;
   toasterId?: string;
 }
 
@@ -144,18 +146,21 @@ export interface ToasterProps {
   mobileOffset?: Offset;
   dir?: 'rtl' | 'ltr' | 'auto';
   swipeDirections?: SwipeDirection[];
+  enterFrom?: EnterFromDirection;
   icons?: ToastIcons;
   customAriaLabel?: string;
   containerAriaLabel?: string;
 }
 
 export type SwipeDirection = 'top' | 'right' | 'bottom' | 'left';
+export type EnterFromDirection = 'left' | 'right';
 
 export interface ToastProps {
   toast: ToastT;
   toasts: ToastT[];
   index: number;
   swipeDirections?: SwipeDirection[];
+  enterFrom?: EnterFromDirection;
   expanded: boolean;
   invert: boolean;
   heights: HeightT[];

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -369,6 +369,9 @@ export default function Home({ searchParams }: any) {
       <Toaster
         offset={32}
         position={searchParams.position || 'bottom-right'}
+        enterFrom={
+          searchParams.enterFrom === 'left' || searchParams.enterFrom === 'right' ? searchParams.enterFrom : undefined
+        }
         toastOptions={{
           actionButtonStyle: { backgroundColor: 'rgb(219, 239, 255)' },
           cancelButtonStyle: { backgroundColor: 'rgb(254, 226, 226)' },

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -338,3 +338,11 @@ test.describe('Basic functionality', () => {
     await expect(page.getByTestId('promise-test-toast')).toHaveText('Loaded');
   });
 });
+
+test('applies enterFrom attribute to toast when set', async ({ page }) => {
+  await page.goto('/?position=bottom-right&enterFrom=left');
+  await page.getByTestId('default-button').click();
+  const toast = page.locator('[data-sonner-toast]');
+  await expect(toast).toBeVisible();
+  await expect(toast).toHaveAttribute('data-enter-from', 'left');
+});


### PR DESCRIPTION
Closes #671.

This PR adds a way to control which horizontal side a toast should enter from, without changing the existing default behavior.

### What’s new

* Introduces an `EnterFromDirection` type:

  ```ts
  export type EnterFromDirection = 'left' | 'right';
  ```
* Adds an optional `enterFrom?: EnterFromDirection` prop to:

  * `ToastT`
  * `ToastProps`
  * `ToastOptions`
  * `ToasterProps`

### Behaviour & precedence

* `enterFrom` can be set:

  * Per toast: `toast('Message', { enterFrom: 'left' })`
  * On the `Toaster`: `<Toaster enterFrom="left" />`
  * In `toastOptions` on the `Toaster`
* Precedence:

  1. Per-toast `enterFrom`
  2. `Toaster` `enterFrom` prop
  3. `toastOptions.enterFrom`
* When `enterFrom` is not provided, the current behaviour is preserved.

### Implementation details

* Each toast now has a `data-enter-from` attribute so the entry direction can be styled in CSS.
* The base transform is split into two parts:

  * `--initial-x` (horizontal offset)
  * `--y` (existing vertical stacking)
* Updated CSS to:

  * Slide toasts in from the configured side (`left` or `right`)
  * Make the front toast exit horizontally in the same direction instead of using the default vertical animation.

### Testing

* Added a Playwright test to assert that `enterFrom` is rendered on the toast when set via query string in the test app:

  * `applies enterFrom attribute to toast when set`
* Ran `pnpm test` locally:

  * All existing tests pass except for the known flaky `cancel button dismisses the custom toast with empty id` case, which is already failing on the current main build as well (so it should be unrelated to this change).