### PR TITLE
Fix: Test for dismissal of custom toast with empty ID relies on non-existing element

### DIFF
--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -274,7 +274,7 @@ test.describe('Basic functionality', () => {
     await page.getByTestId('custom-with-empty-id').click();
 
     await expect(page.locator('[data-sonner-toast]')).toHaveCount(1);
-    await page.locator('[data-dismiss]').click();
+    await page.getByTestId('dismiss-button').click();
     await expect(page.locator('[data-sonner-toast]')).toHaveCount(0);
   });
 


### PR DESCRIPTION
I noticed that test called `cancel button dismisses the custom toast with empty id` fails every time. 

It was trying to click on `[data-dismiss]` element, but if you look at the button in the testing Next.js environment, it doesn't have this attribute. It should use `page.getByTestId('dismiss-button')` reference.

<img width="877" height="375" alt="image" src="https://github.com/user-attachments/assets/e95eb138-6a2f-433a-a520-a145a88b0bf1" />
