### PR TITLE
[Proof only] Fix: re-creation of toast just after it dismissal prevents its re-render

### DIFF
--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -351,6 +351,20 @@ export default function Home({ searchParams }: any) {
         Toast with testId
       </button>
       <button
+        data-testid="loading-with-id-toast-button"
+        className="button"
+        onClick={() => toast.loading('Loading state...', { id: 'my-loading-toast', testId: 'my-loading-toast' })}
+      >
+        Render Loading toast with ID
+      </button>
+      <button
+        data-testid="dismiss-loading-with-id-toast-button"
+        className="button"
+        onClick={() => toast.dismiss('my-loading-toast')}
+      >
+        Dismiss Loading toast with ID
+      </button>
+      <button
         data-testid="testid-promise-toast-button"
         className="button"
         onClick={() =>

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -337,4 +337,26 @@ test.describe('Basic functionality', () => {
     await expect(page.getByTestId('promise-test-toast')).toHaveText('Loading...');
     await expect(page.getByTestId('promise-test-toast')).toHaveText('Loaded');
   });
+
+  test('toast can be created, dismissed and re-created with the same ID', async ({ page }) => {
+    // Create the toast, dismiss it and create it again. It should be done without any additional waits,
+    // as this reproduces issue with state becoming stale.
+    await page.getByTestId('loading-with-id-toast-button').click();
+    await expect(page.getByTestId('my-loading-toast')).toBeVisible();
+
+    // Dismiss it. Don't wait for it to disappear. We want to trigger race condition.
+    await page.getByTestId('dismiss-loading-with-id-toast-button').click();
+
+    // Re-create the toast with the same ID.
+    await page.getByTestId('loading-with-id-toast-button').click();
+
+    // Give React 20 frames to process the toast re-creation. We need to do it, as toasts may become out of sync
+    // a little bit due to state updates.
+    for (let i = 0; i < 20; i++) {
+      await page.evaluate(() => new Promise(requestAnimationFrame));
+    }
+
+    await expect(page.getByTestId('my-loading-toast')).toBeVisible();
+    await expect(page.getByTestId('my-loading-toast')).toContainText('Loading state...');
+  });
 });


### PR DESCRIPTION
I see that when I quickly create, dismiss, and recreate the same toast, it disappears instead of staying there. It often happens for me. I believe that's related to #592 bug report.

@emilkowalski I don't have a fix for that, but I added a test that reproduces this bug. I believe the issue comes down to the state management, as I see that dismissed toast is not removed from `Observer.toasts` state right away. I tried to change that, but I did something wrong, or there is some additional dependency from `src/index.tsx`.

From what I noticed, there are some additional calls to `toast.dismiss` after the last creation call. I believe they come from the `removeToast` function (`src/index.tsx` file). I believe that if we can remove this back-synchronization of state from React to Observer, we may be able to get rid of `setTimeout` and `ReactDOM.flushSync` calls that are below it.

https://github.com/emilkowalski/sonner/blob/fe51da129d1520a5e8d2a5709af88b81e3cee9cc/src/index.tsx#L646-L686