### PR TITLE
Use variables in close button colors instead of hardcoded values

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -227,9 +227,9 @@ html[dir='rtl'],
   justify-content: center;
   align-items: center;
   padding: 0;
-  color: var(--gray12);
+  color: var(--normal-text);
   background: var(--normal-bg);
-  border: 1px solid var(--gray4);
+  border: 1px solid var(--normal-border);
   transform: var(--toast-close-button-transform);
   border-radius: 50%;
   cursor: pointer;


### PR DESCRIPTION
This should be a transparent change. The hardcoded colors are replaced with variables of the same value:

https://github.com/emilkowalski/sonner/blob/5caadb1f6f27abf3678d18cbaa42fff1ff36eb6f/src/styles.css#L465-L466

This was already done for background but not for border and text color:
https://github.com/emilkowalski/sonner/blob/5caadb1f6f27abf3678d18cbaa42fff1ff36eb6f/src/styles.css#L230-L232

### Why?
Using hardcoded values makes it harder to overwrite them. For example, the [overwrite in shadcn](https://github.com/shadcn-ui/ui/blob/f0d147d5810e4187537e1dfcb3ca1ef8ad3cb670/apps/v4/registry/bases/base/ui/sonner.tsx#L64-L67) does not work OOTB without this change.