### PR TITLE
fix: Next.js hydration mismatches, focus ref logic & performance

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 export const useIsDocumentHidden = () => {
-  const [isDocumentHidden, setIsDocumentHidden] = React.useState(document.hidden);
+  const [isDocumentHidden, setIsDocumentHidden] = React.useState(false);
 
   React.useEffect(() => {
+    setIsDocumentHidden(document.hidden);
     const callback = () => {
       setIsDocumentHidden(document.hidden);
     };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -628,17 +628,9 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
   const [heights, setHeights] = React.useState<HeightT[]>([]);
   const [expanded, setExpanded] = React.useState(false);
   const [interacting, setInteracting] = React.useState(false);
-  const [actualTheme, setActualTheme] = React.useState(
-    theme !== 'system'
-      ? theme
-      : typeof window !== 'undefined'
-      ? window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light'
-      : 'light',
-  );
+  const [actualTheme, setActualTheme] = React.useState(theme !== 'system' ? theme : 'light');
 
-  const listRef = React.useRef<HTMLOListElement>(null);
+  const listRefs = React.useRef<Array<HTMLOListElement | null>>([]);
   const hotkeyLabel = hotkey.join('+').replace(/Key/g, '').replace(/Digit/g, '');
   const lastFocusedElementRef = React.useRef<HTMLElement>(null);
   const isFocusWithinRef = React.useRef(false);
@@ -683,7 +675,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
         });
       });
     });
-  }, [toasts]);
+  }, []);
 
   React.useEffect(() => {
     if (theme !== 'system') {
@@ -743,12 +735,16 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
 
       if (isHotkeyPressed) {
         setExpanded(true);
-        listRef.current?.focus();
+        const firstValidList = listRefs.current.find((el) => el);
+        firstValidList?.focus();
       }
 
       if (
         event.code === 'Escape' &&
-        (document.activeElement === listRef.current || listRef.current?.contains(document.activeElement))
+        (document.activeElement === null ||
+          listRefs.current.some(
+            (listRef) => listRef === document.activeElement || listRef?.contains(document.activeElement),
+          ))
       ) {
         setExpanded(false);
       }
@@ -759,16 +755,14 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
   }, [hotkey]);
 
   React.useEffect(() => {
-    if (listRef.current) {
-      return () => {
-        if (lastFocusedElementRef.current) {
-          lastFocusedElementRef.current.focus({ preventScroll: true });
-          lastFocusedElementRef.current = null;
-          isFocusWithinRef.current = false;
-        }
-      };
-    }
-  }, [listRef.current]);
+    return () => {
+      if (lastFocusedElementRef.current) {
+        lastFocusedElementRef.current.focus({ preventScroll: true });
+        lastFocusedElementRef.current = null;
+        isFocusWithinRef.current = false;
+      }
+    };
+  }, []);
 
   return (
     // Remove item from normal navigation flow, only available via hotkey
@@ -792,7 +786,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
             key={position}
             dir={dir === 'auto' ? getDocumentDirection() : dir}
             tabIndex={-1}
-            ref={listRef}
+            ref={(el) => (listRefs.current[index] = el)}
             className={className}
             data-sonner-toaster
             data-sonner-theme={actualTheme}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -741,10 +741,9 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
 
       if (
         event.code === 'Escape' &&
-        (document.activeElement === null ||
-          listRefs.current.some(
-            (listRef) => listRef === document.activeElement || listRef?.contains(document.activeElement),
-          ))
+        listRefs.current.some(
+          (listRef) => listRef === document.activeElement || listRef?.contains(document.activeElement),
+        )
       ) {
         setExpanded(false);
       }


### PR DESCRIPTION
## Summary
This PR addresses three critical issues identified during integration with Next.js (App Router):

1.  **Hydration Mismatches (SSR):** Fixed `window` and `document` usage during initial render in `useIsDocumentHidden` and `actualTheme`. This eliminates console errors like `Text content does not match server-rendered HTML` in Next.js applications.
2.  **Focus Management (A11y):** Fixed a logic error where `listRef` was being overwritten in the render loop. Converted it to `listRefs` (array) to correctly handle multiple toaster positions. Now, the hotkey correctly focuses the first available list instead of only the last one.
3.  **Performance:** Optimized the `Toaster` subscription effect by removing `[toasts]` from the dependency array, preventing unnecessary re-subscriptions on every state update.

## Changes
- `src/hooks.tsx`: Initialized state with `false` instead of `document.hidden`.
- `src/index.tsx`:
    - Deterministic theme initialization for SSR safety.
    - Implemented `listRefs` array pattern.
    - Fixed `handleKeyDown` to find and focus the first valid list (`.find(el => el)`).
    - Cleaned up `useEffect` dependencies.