### PR TITLE
Fix SVG accessibility by adding aria-hidden (#713)

### DIFF
--- a/src/assets.tsx
+++ b/src/assets.tsx
@@ -36,7 +36,7 @@ export const Loader = ({ visible, className }: { visible: boolean; className?: s
 };
 
 const SuccessIcon = (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" height="20" width="20">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" height="20" width="20" aria-hidden="true">
     <path
       fillRule="evenodd"
       d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
@@ -46,7 +46,7 @@ const SuccessIcon = (
 );
 
 const WarningIcon = (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" height="20" width="20">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" height="20" width="20" aria-hidden="true">
     <path
       fillRule="evenodd"
       d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z"
@@ -56,7 +56,7 @@ const WarningIcon = (
 );
 
 const InfoIcon = (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" height="20" width="20">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" height="20" width="20" aria-hidden="true">
     <path
       fillRule="evenodd"
       d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z"
@@ -66,7 +66,7 @@ const InfoIcon = (
 );
 
 const ErrorIcon = (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" height="20" width="20">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" height="20" width="20" aria-hidden="true">
     <path
       fillRule="evenodd"
       d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
@@ -86,6 +86,7 @@ export const CloseIcon = (
     strokeWidth="1.5"
     strokeLinecap="round"
     strokeLinejoin="round"
+    aria-hidden="true"
   >
     <line x1="18" y1="6" x2="6" y2="18"></line>
     <line x1="6" y1="6" x2="18" y2="18"></line>


### PR DESCRIPTION
## Problem

IBM Equal Access Accessibility Checker reports violations for SVG elements without accessible names (Issue #713). These SVG icons in toast notifications lack proper accessibility attributes, causing potential issues for assistive technologies.

## Solution

Added `aria-hidden="true"` attribute to all decorative SVG icons in `src/assets.tsx`:
- `CloseIcon`
- `SuccessIcon`
- `ErrorIcon`
- `WarningIcon`
- `InfoIcon`

## Why `aria-hidden="true"`?

These SVG icons are **purely decorative** and should be hidden from assistive technologies because:

1. **Redundant information**: The toast's meaning is already conveyed through:
   - Text content (title and description)
   - `data-type` attribute on the toast element
   - `aria-label` on the close button

2. **Prevents confusion**: Without `aria-hidden`, screen readers may announce redundant information like "Success icon, graphic, My success message", which creates a poor user experience.

3. **Follows WCAG best practices**: [WCAG 2.1 guidelines](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html) recommend hiding decorative images from assistive technologies to avoid unnecessary verbosity.

4. **Consistent behavior**: Ensures the same experience across different screen readers and accessibility tools.

## Verification

- ✅ Visual inspection: All toasts render correctly
- ✅ DOM inspection: `aria-hidden="true"` attribute present on all SVG elements
- ✅ IBM Equal Access Accessibility Checker: Violations resolved
- ✅ No breaking changes to existing functionality

### Before
```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" ...>
  <!-- No aria-hidden attribute -->
</svg>
```
<img width="1456" height="786" alt="before_aria_error" src="https://github.com/user-attachments/assets/0255f051-9215-4dbc-b499-d025cd943f1d" />

### After
IBM Equal Access Accessibility Checker's Violations are resolved.

<img width="969" height="699" alt="no-error" src="https://github.com/user-attachments/assets/f73301e7-2f4a-4ee4-ad93-39a5015113f4" />


## Testing Notes
Existing Playwright tests appear to have pre-existing failures unrelated to this change. The accessibility improvements do not affect visual rendering or functionality—only how assistive technologies interpret the icons.

Fixes #713 
