### PR TITLE
Add clearHistory method to allow manual toast history cleanup

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -249,6 +249,11 @@ class Observer {
   getActiveToasts = () => {
     return this.toasts.filter((toast) => !this.dismissedToasts.has(toast.id));
   };
+
+  clearHistory = () => {
+    this.toasts = this.getActiveToasts();
+    this.dismissedToasts.clear();
+  };
 }
 
 export const ToastState = new Observer();
@@ -280,6 +285,7 @@ const basicToast = toastFunction;
 
 const getHistory = () => ToastState.toasts;
 const getToasts = () => ToastState.getActiveToasts();
+const clearHistory = () => ToastState.clearHistory();
 
 // We use `Object.assign` to maintain the correct types as we would lose them otherwise
 export const toast = Object.assign(
@@ -295,5 +301,5 @@ export const toast = Object.assign(
     dismiss: ToastState.dismiss,
     loading: ToastState.loading,
   },
-  { getHistory, getToasts },
+  { getHistory, getToasts, clearHistory },
 );


### PR DESCRIPTION
Problem
Dismissed toasts are never removed from ToastState.toasts, causing the array to grow indefinitely. This is especially problematic in long-running SPAs with JSX-heavy toasts, as full React element trees are retained and never garbage collected.

Relates to [#729](https://github.com/emilkowalski/sonner/issues/729)

Solution
Adds toast.clearHistory() method that removes dismissed toasts from the history while preserving active ones.

```ts
// Usage
toast.clearHistory();
```
Why not automatic cleanup?
getHistory() is intentionally designed to return all toasts including dismissed ones. This PR respects that design by providing an opt-in manual cleanup instead of automatic eviction.