### PR TITLE
feat: add vibration effect for duplicate toasts

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,6 +96,7 @@ const Toast = (props: ToastProps) => {
   const [swiping, setSwiping] = React.useState(false);
   const [swipeOut, setSwipeOut] = React.useState(false);
   const [isSwiped, setIsSwiped] = React.useState(false);
+  const [vibrating, setVibrating] = React.useState(false);
   const [offsetBeforeRemove, setOffsetBeforeRemove] = React.useState(0);
   const [initialHeight, setInitialHeight] = React.useState(0);
   const remainingTime = React.useRef(toast.duration || durationFromToaster || TOAST_LIFETIME);
@@ -241,6 +242,23 @@ const Toast = (props: ToastProps) => {
     }
   }, [deleteToast, toast.delete]);
 
+  React.useEffect(() => {
+    if (!toast.duplicateCount) return;
+
+    setVibrating(false);
+    const frame = requestAnimationFrame(() => {
+      setVibrating(true);
+    });
+    const timeout = setTimeout(() => {
+      setVibrating(false);
+    }, 320);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      clearTimeout(timeout);
+    };
+  }, [toast.duplicateCount]);
+
   function getLoadingIcon() {
     if (icons?.loading) {
       return (
@@ -284,6 +302,8 @@ const Toast = (props: ToastProps) => {
       data-index={index}
       data-front={isFront}
       data-swiping={swiping}
+      data-vibrating={vibrating}
+      data-vibration-count={toast.duplicateCount || 0}
       data-dismissible={dismissible}
       data-type={toastType}
       data-invert={invert}

--- a/src/state.ts
+++ b/src/state.ts
@@ -16,7 +16,7 @@ type titleT = (() => React.ReactNode) | React.ReactNode;
 
 class Observer {
   subscribers: Array<(toast: ExternalToast | ToastToDismiss) => void>;
-  toasts: Array<ToastT | ToastToDismiss>;
+  toasts: Array<ToastT>;
   dismissedToasts: Set<string | number>;
 
   constructor() {
@@ -53,11 +53,43 @@ class Observer {
     },
   ) => {
     const { message, ...rest } = data;
-    const id = typeof data?.id === 'number' || data.id?.length > 0 ? data.id : toastsCounter++;
+    const hasCustomId = typeof data?.id === 'number' || (typeof data?.id === 'string' && data.id.length > 0);
+    const dismissible = data.dismissible === undefined ? true : data.dismissible;
+
+    if (!hasCustomId && data.vibrateOnDuplicate) {
+      const duplicateToast = this.toasts.find((toast) => {
+        if (this.dismissedToasts.has(toast.id)) return false;
+
+        return (
+          toast.title === message &&
+          toast.type === data.type &&
+          toast.description === data.description &&
+          toast.toasterId === data.toasterId
+        );
+      });
+
+      if (duplicateToast) {
+        const duplicateCount = (duplicateToast.duplicateCount || 0) + 1;
+        const updatedToast = {
+          ...duplicateToast,
+          ...rest,
+          id: duplicateToast.id,
+          dismissible,
+          title: message,
+          duplicateCount,
+        };
+
+        this.publish(updatedToast);
+        this.toasts = this.toasts.map((toast) => (toast.id === duplicateToast.id ? updatedToast : toast));
+
+        return duplicateToast.id;
+      }
+    }
+
+    const id = hasCustomId ? data.id : toastsCounter++;
     const alreadyExists = this.toasts.find((toast) => {
       return toast.id === id;
     });
-    const dismissible = data.dismissible === undefined ? true : data.dismissible;
 
     if (this.dismissedToasts.has(id)) {
       this.dismissedToasts.delete(id);
@@ -255,14 +287,7 @@ export const ToastState = new Observer();
 
 // bind this to the toast function
 const toastFunction = (message: titleT, data?: ExternalToast) => {
-  const id = data?.id || toastsCounter++;
-
-  ToastState.addToast({
-    title: message,
-    ...data,
-    id,
-  });
-  return id;
+  return ToastState.create({ message, ...data });
 };
 
 const isHttpResponse = (data: any): data is Response => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -322,6 +322,10 @@ html[dir='rtl'],
   height: var(--initial-height);
 }
 
+[data-sonner-toast][data-vibrating='true'] {
+  animation: sonner-vibrate 0.32s ease-in-out;
+}
+
 [data-sonner-toast][data-removed='true'][data-front='true'][data-swipe-out='false'] {
   --y: translateY(calc(var(--lift) * -100%));
   opacity: 0;
@@ -698,6 +702,25 @@ html[dir='rtl'],
   }
   100% {
     opacity: 0.15;
+  }
+}
+
+@keyframes sonner-vibrate {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  20% {
+    translate: -4px 0;
+  }
+  40% {
+    translate: 4px 0;
+  }
+  60% {
+    translate: -3px 0;
+  }
+  80% {
+    translate: 3px 0;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,8 @@ export interface ToastT {
   descriptionClassName?: string;
   position?: Position;
   testId?: string;
+  vibrateOnDuplicate?: boolean;
+  duplicateCount?: number;
 }
 
 export function isAction(action: Action | React.ReactNode): action is Action {
@@ -194,7 +196,7 @@ export interface ToastToDismiss {
   dismiss: boolean;
 }
 
-export type ExternalToast = Omit<ToastT, 'id' | 'type' | 'title' | 'jsx' | 'delete' | 'promise'> & {
+export type ExternalToast = Omit<ToastT, 'id' | 'type' | 'title' | 'jsx' | 'delete' | 'promise' | 'duplicateCount'> & {
   id?: number | string;
   toasterId?: string;
 };

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -364,6 +364,18 @@ export default function Home({ searchParams }: any) {
       >
         Promise Toast with testId
       </button>
+      <button
+        data-testid="vibrate-on-duplicate"
+        className="button"
+        onClick={() =>
+          toast('Do not duplicate this toast', {
+            testId: 'vibrate-target-toast',
+            vibrateOnDuplicate: true,
+          })
+        }
+      >
+        Vibrate existing toast on duplicate
+      </button>
       {showAutoClose ? <div data-testid="auto-close-el" /> : null}
       {showDismiss ? <div data-testid="dismiss-el" /> : null}
       <Toaster

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -247,6 +247,16 @@ test.describe('Basic functionality', () => {
     await expect(page.getByText('My Updated Toast')).toHaveCount(1);
   });
 
+  test('duplicate toast vibrates existing toast instead of creating a new one', async ({ page }) => {
+    await page.getByTestId('vibrate-on-duplicate').click();
+    await expect(page.getByTestId('vibrate-target-toast')).toHaveCount(1);
+    await expect(page.getByTestId('vibrate-target-toast')).toHaveAttribute('data-vibration-count', '0');
+
+    await page.getByTestId('vibrate-on-duplicate').click();
+    await expect(page.getByTestId('vibrate-target-toast')).toHaveCount(1);
+    await expect(page.getByTestId('vibrate-target-toast')).toHaveAttribute('data-vibration-count', '1');
+  });
+
   test('should update toast content and duration after 3 seconds', async ({ page }) => {
     await page.getByTestId('update-toast-duration').click();
 

--- a/website/src/pages/toast.mdx
+++ b/website/src/pages/toast.mdx
@@ -233,22 +233,32 @@ You can target a specific Toaster by passing a `toasterId` option:
 toast('This will show in the canvas Toaster', { toasterId: 'canvas' });
 ```
 
+### Vibrating duplicates
+
+Set `vibrateOnDuplicate` to `true` to avoid creating the same toast multiple times. When a duplicate is triggered,
+the existing toast is vibrated instead.
+
+```jsx
+toast('Saved', { vibrateOnDuplicate: true });
+```
+
 ## API Reference
 
-| Property          |                                              Description                                               |        Default |
-| :---------------- | :----------------------------------------------------------------------------------------------------: | -------------: |
-| description       |                           Toast's description, renders underneath the title.                           |            `-` |
-| closeButton       |                                          Adds a close button.                                          |        `false` |
-| invert            |                                Dark toast in light mode and vice versa.                                |        `false` |
-| duration          |            Time in milliseconds that should elapse before automatically closing the toast.             |         `4000` |
-| position          |                                         Position of the toast.                                         | `bottom-right` |
-| dismissible       |                     If `false`, it'll prevent the user from dismissing the toast.                      |         `true` |
-| icon              |                      Icon displayed in front of toast's text, aligned vertically.                      |            `-` |
-| action            |                      Renders a primary button, clicking it will close the toast.                       |            `-` |
-| cancel            |                     Renders a secondary button, clicking it will close the toast.                      |            `-` |
-| id                |                                        Custom id for the toast.                                        |            `-` |
-| onDismiss         |       The function gets called when either the close button is clicked, or the toast is swiped.        |            `-` |
-| onAutoClose       | Function that gets called when the toast disappears automatically after it's timeout (duration` prop). |            `-` |
-| unstyled          |                  Removes the default styling, which allows for easier customization.                   |        `false` |
-| actionButtonStyle |                                      Styles for the action button                                      |           `{}` |
-| cancelButtonStyle |                                      Styles for the cancel button                                      |           `{}` |
+| Property           |                                              Description                                               |        Default |
+| :----------------- | :----------------------------------------------------------------------------------------------------: | -------------: |
+| description        |                           Toast's description, renders underneath the title.                           |            `-` |
+| closeButton        |                                          Adds a close button.                                          |        `false` |
+| invert             |                                Dark toast in light mode and vice versa.                                |        `false` |
+| duration           |            Time in milliseconds that should elapse before automatically closing the toast.             |         `4000` |
+| position           |                                         Position of the toast.                                         | `bottom-right` |
+| dismissible        |                     If `false`, it'll prevent the user from dismissing the toast.                      |         `true` |
+| icon               |                      Icon displayed in front of toast's text, aligned vertically.                      |            `-` |
+| action             |                      Renders a primary button, clicking it will close the toast.                       |            `-` |
+| cancel             |                     Renders a secondary button, clicking it will close the toast.                      |            `-` |
+| id                 |                                        Custom id for the toast.                                        |            `-` |
+| vibrateOnDuplicate |         If `true`, duplicate toasts vibrate the existing toast instead of creating a new one.          |        `false` |
+| onDismiss          |       The function gets called when either the close button is clicked, or the toast is swiped.        |            `-` |
+| onAutoClose        | Function that gets called when the toast disappears automatically after it's timeout (duration` prop). |            `-` |
+| unstyled           |                  Removes the default styling, which allows for easier customization.                   |        `false` |
+| actionButtonStyle  |                                      Styles for the action button                                      |           `{}` |
+| cancelButtonStyle  |                                      Styles for the cancel button                                      |           `{}` |


### PR DESCRIPTION
### Summary
Added new `vibrateOnDuplicate` prop for preventing duplicate _sonners_

### Usage
```
 toast('Do not duplicate this toast', {
            vibrateOnDuplicate: true,
          })
```


https://github.com/user-attachments/assets/77e9f9f9-72c7-40dc-b9dd-9274c6dd8adf



