### PR TITLE
fix: icon animation when updating toast.loading() to another type (#743)

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -119,7 +119,7 @@ class Observer {
   };
 
   loading = (message: titleT | React.ReactNode, data?: ExternalToast) => {
-    return this.create({ ...data, type: 'loading', message });
+    return this.create({ ...data, type: 'loading', message, promise: Promise.resolve() });
   };
 
   promise = <ToastData>(promise: PromiseT<ToastData>, data?: PromiseData<ToastData>) => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -119,7 +119,9 @@ class Observer {
   };
 
   loading = (message: titleT | React.ReactNode, data?: ExternalToast) => {
-    return this.create({ ...data, type: 'loading', message, promise: Promise.resolve() });
+    /** iconAnimationPromise is a no-op used to set data-promise. It triggers icon fade-in on state change. **/
+    const iconAnimationPromise = Promise.resolve();
+    return this.create({ ...data, type: 'loading', message, promise: iconAnimationPromise });
   };
 
   promise = <ToastData>(promise: PromiseT<ToastData>, data?: PromiseData<ToastData>) => {

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -89,6 +89,18 @@ export default function Home({ searchParams }: any) {
         Loading to Success Toast
       </button>
       <button
+        data-testid="loading-to-error"
+        className="button"
+        onClick={() => {
+          const toastId = toast.loading('Loading...');
+          setTimeout(() => {
+            toast.error('Failed.', { id: toastId });
+          }, 2000);
+        }}
+      >
+        Loading to Error Toast
+      </button>
+      <button
         data-testid="rsf-promise"
         data-finally={isFinally ? '1' : '0'}
         className="button"

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -77,6 +77,18 @@ export default function Home({ searchParams }: any) {
         Render Promise Toast
       </button>
       <button
+        data-testid="loading-to-success"
+        className="button"
+        onClick={() => {
+          const toastId = toast.loading('Loading...');
+          setTimeout(() => {
+            toast.success('Loaded.', { id: toastId });
+          }, 2000);
+        }}
+      >
+        Loading to Success Toast
+      </button>
+      <button
         data-testid="rsf-promise"
         data-finally={isFinally ? '1' : '0'}
         className="button"

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -38,6 +38,15 @@ test.describe('Basic functionality', () => {
     await expect(page.getByText('Loaded.')).toHaveCount(1);
   });
 
+  test('toast.loading updated to toast.error via setTimeout preserves promise attribute for animation', async ({ page }) => {
+    await page.getByTestId('loading-to-error').click();
+    const toast = page.locator('[data-sonner-toast]');
+    await expect(toast).toHaveAttribute('data-type', 'loading');
+    await expect(toast).toHaveAttribute('data-promise', 'true');
+    await expect(toast).toHaveAttribute('data-type', 'error');
+    await expect(page.getByText('Failed.')).toHaveCount(1);
+  });
+
   test('handle toast promise rejections', async ({ page }) => {
     const rejectedPromise = new Promise((_, reject) => setTimeout(() => reject(new Error('Promise rejected')), 100));
     try {

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -29,6 +29,15 @@ test.describe('Basic functionality', () => {
     await expect(page.getByText('Loaded')).toHaveCount(1);
   });
 
+  test('toast.loading updated to toast.success via setTimeout preserves promise attribute for animation', async ({ page }) => {
+    await page.getByTestId('loading-to-success').click();
+    const toast = page.locator('[data-sonner-toast]');
+    await expect(toast).toHaveAttribute('data-type', 'loading');
+    await expect(toast).toHaveAttribute('data-promise', 'true');
+    await expect(toast).toHaveAttribute('data-type', 'success');
+    await expect(page.getByText('Loaded.')).toHaveCount(1);
+  });
+
   test('handle toast promise rejections', async ({ page }) => {
     const rejectedPromise = new Promise((_, reject) => setTimeout(() => reject(new Error('Promise rejected')), 100));
     try {


### PR DESCRIPTION
Fixes https://github.com/emilkowalski/sonner/issues/743

Summary
Fix missing icon transition animation when updating a toast created with toast.loading() to another type (e.g. toast.success()) using the same id.

Previously, the success icon appeared instantly without the fade animation that works correctly with toast.promise().

⸻

Root Cause

The icon transition animation depends on the promise field:
• toast.promise() sets promise
• → adds data-promise='true' which triggers the CSS fade-in
• → keeps the loader in the DOM during type transitions
• toast.loading() did not set promise
• → loader was removed immediately on type change
• → success icon rendered without animation

⸻

Fix
Set promise: Promise.resolve() in toast.loading() so it reuses the existing animation path.

Single-line change in state.ts, no rendering logic changes required.

++
Added a Playwright test covering the toast.loading() → toast.success() transition to ensure the data-promise attribute is preserved for animation.