### PR TITLE
fix: clip custom toast content overflow in stacked view

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -723,3 +723,9 @@ html[dir='rtl'],
   opacity: 0;
   transform: scale(0.8) translate(-50%, -50%);
 }
+
+[data-sonner-toast][data-front='false'] [data-content] {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}


### PR DESCRIPTION
## What does this PR fix?

Fixes #748 

## Problem

When using `toast.custom()`, stacking a short toast in front of a tall toast 
causes the bottom of the taller toast to bleed through the shorter front toast. 
Default toasts are unaffected — the issue is isolated to custom/JSX toasts.

## Root Cause

Sonner clips the stack using `--front-toast-height` on the list container. For 
default toasts, overflow is handled implicitly by their internal structure. For 
custom toasts, the `[data-content]` wrapper grows to its natural content height 
and punches through the parent's clipped boundary because it never receives 
`overflow: hidden` or `height: 100%`.

## Fix

Added a CSS rule scoped to `[data-front='false']` that constrains `[data-content]` 
to the parent's height and clips the overflow:
```css
[data-sonner-toast][data-front='false'] [data-content] {
  height: 100%;
  width: 100%;
  overflow: hidden;
}
```

This is tightly scoped — it only applies to non-front toasts in the stack, 
so it has zero impact on the front toast or any other state.

## Testing

Manually verified with tall + short `toast.custom()` combinations in 
Chrome, Firefox, and Safari.

## Demo

**Before**

https://github.com/user-attachments/assets/61de460a-63ed-42a9-b130-8c19890b2057

**After**

https://github.com/user-attachments/assets/6f6b0653-d1fa-4c9c-8411-295a2779fafd