### PR TITLE
fix: Fix wrong height on toast update

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -167,9 +167,15 @@ const Toast = (props: ToastProps) => {
     if (!mounted) return;
     const toastNode = toastRef.current;
     const originalHeight = toastNode.style.height;
+    const originalTransition = toastNode.style.transition;
+    const originalTransform = toastNode.style.transform;
     toastNode.style.height = 'auto';
+    toastNode.style.transition = 'none';
+    toastNode.style.transform = 'none';
     const newHeight = toastNode.getBoundingClientRect().height;
     toastNode.style.height = originalHeight;
+    toastNode.style.transform = originalTransform;
+    toastNode.style.transition = originalTransition;
 
     setInitialHeight(newHeight);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -167,24 +167,20 @@ const Toast = (props: ToastProps) => {
     if (!mounted) return;
     const toastNode = toastRef.current;
     const originalHeight = toastNode.style.height;
-    const originalTransition = toastNode.style.transition;
-    const originalTransform = toastNode.style.transform;
     toastNode.style.height = 'auto';
-    toastNode.style.transition = 'none';
-    toastNode.style.transform = 'none';
     const newHeight = toastNode.getBoundingClientRect().height;
     toastNode.style.height = originalHeight;
-    toastNode.style.transform = originalTransform;
-    toastNode.style.transition = originalTransition;
+    // Adjust to --scale property from style.css file
+    const heightAdjustedToScale = expanded ? newHeight : newHeight / (1 - 0.05 * index);
 
-    setInitialHeight(newHeight);
+    setInitialHeight(heightAdjustedToScale);
 
     setHeights((heights) => {
       const alreadyExists = heights.find((height) => height.toastId === toast.id);
       if (!alreadyExists) {
-        return [{ toastId: toast.id, height: newHeight, position: toast.position }, ...heights];
+        return [{ toastId: toast.id, height: heightAdjustedToScale, position: toast.position }, ...heights];
       } else {
-        return heights.map((height) => (height.toastId === toast.id ? { ...height, height: newHeight } : height));
+        return heights.map((height) => (height.toastId === toast.id ? { ...height, height: heightAdjustedToScale } : height));
       }
     });
   }, [mounted, toast.title, toast.description, setHeights, toast.id, toast.jsx, toast.action, toast.cancel]);


### PR DESCRIPTION
I've noticed that when toasts with expanded="false" are updated, their height is recalculated incorrectly. This happens because the scale is not cleared before reading the height, resulting in an inaccurate measurement.

It can lead to such behavior after expanding the toasts later
<img width="418" height="1203" alt="image" src="https://github.com/user-attachments/assets/48d5a27a-57b5-4a07-a5b7-f054c43267b0" />


The provided fix may still fail if the height is calculated within the 400ms transition window, but I don't currently see a better solution.