### PR TITLE
fix: do not apply hardcoded description color on custom themes

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -127,11 +127,14 @@ html[dir='rtl'],
 [data-sonner-toast][data-styled='true'] [data-description] {
   font-weight: 400;
   line-height: 1.4;
-  color: #3f3f3f;
 }
 
 [data-rich-colors='true'][data-sonner-toast][data-styled='true'] [data-description] {
   color: inherit;
+}
+
+[data-sonner-toaster][data-sonner-theme='light'] [data-description] {
+  color: #3f3f3f;
 }
 
 [data-sonner-toaster][data-sonner-theme='dark'] [data-description] {


### PR DESCRIPTION
## Problem

I use sonner in combination with a custom theme (without `richColors`).

Whilst `[data-title]` uses `color: inherit;`, `[data-description]` uses `#3f3f3f`.

## Solution

Explicitly use the hardcoded value `#3f3f3f` when `[data-sonner-theme='light']` and therefore inherit the color value when theme is anything else except `light` or `dark`.