### PR TITLE
fix: only apply classNames.default to default-type toasts

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -267,7 +267,7 @@ const Toast = (props: ToastProps) => {
         toastClassname,
         classNames?.toast,
         toast?.classNames?.toast,
-        classNames?.default,
+        toastType === 'default' ? classNames?.default : undefined,
         classNames?.[toastType],
         toast?.classNames?.[toastType],
       )}


### PR DESCRIPTION
Closes #744

`classNames.default` was being applied to every toast regardless of type, making it identical to `classNames.toast`. Now it only applies when `toastType === 'default'`, so `toast.success()` / `toast.error()` / etc. won't get the default class.