### PR TITLE
fix: deliver toasts queued before Toaster subscribes (#723)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -683,7 +683,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
         });
       });
     });
-  }, [toasts]);
+  }, []);
 
   React.useEffect(() => {
     if (theme !== 'system') {

--- a/src/state.ts
+++ b/src/state.ts
@@ -29,9 +29,18 @@ class Observer {
   subscribe = (subscriber: (toast: ToastT | ToastToDismiss) => void) => {
     this.subscribers.push(subscriber);
 
+    // Replay toasts queued before this subscriber attached (issue #723).
+    for (const toast of this.toasts) {
+      if ('dismiss' in toast && (toast as ToastToDismiss).dismiss) continue;
+      if (this.dismissedToasts.has(toast.id)) continue;
+      subscriber(toast);
+    }
+
     return () => {
       const index = this.subscribers.indexOf(subscriber);
-      this.subscribers.splice(index, 1);
+      if (index !== -1) {
+        this.subscribers.splice(index, 1);
+      }
     };
   };
 

--- a/test/src/app/issue-723/page.tsx
+++ b/test/src/app/issue-723/page.tsx
@@ -6,7 +6,10 @@ import { Toaster, toast } from 'sonner';
 // Sibling rendered ABOVE <Toaster /> — its useEffect runs before the Toaster's,
 // so toast() fires before ToastState has a subscriber. See issue #723.
 function ToastOnMount() {
+  const fired = React.useRef(false);
   React.useEffect(() => {
+    if (fired.current) return;
+    fired.current = true;
     toast('Toast fired before Toaster subscribed');
   }, []);
   return null;

--- a/test/src/app/issue-723/page.tsx
+++ b/test/src/app/issue-723/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import React from 'react';
+import { Toaster, toast } from 'sonner';
+
+// Sibling rendered ABOVE <Toaster /> — its useEffect runs before the Toaster's,
+// so toast() fires before ToastState has a subscriber. See issue #723.
+function ToastOnMount() {
+  React.useEffect(() => {
+    toast('Toast fired before Toaster subscribed');
+  }, []);
+  return null;
+}
+
+export default function Issue723Page() {
+  return (
+    <>
+      <ToastOnMount />
+      <Toaster />
+    </>
+  );
+}

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -337,4 +337,10 @@ test.describe('Basic functionality', () => {
     await expect(page.getByTestId('promise-test-toast')).toHaveText('Loading...');
     await expect(page.getByTestId('promise-test-toast')).toHaveText('Loaded');
   });
+
+  // Regression for https://github.com/emilkowalski/sonner/issues/723
+  test('toast fired before Toaster subscribes is still displayed', async ({ page }) => {
+    await page.goto('/issue-723');
+    await expect(page.getByText('Toast fired before Toaster subscribed')).toHaveCount(1);
+  });
 });


### PR DESCRIPTION
Closes #723.

## Problem

`toast(...)` called before `<Toaster />` mounts (e.g. from a sibling
component's `useEffect`, which runs before the parent's) was silently
dropped. `Observer.addToast` publishes to `subscribers`, but
`Toaster.subscribe` only attaches inside its own `useEffect`, so any
toast added before that ran was never delivered. The user could see it
in `ToastState.toasts` but it never reached the DOM.

The only workarounds were `setTimeout(0)` around the `toast()` call or
re-ordering the component tree so `<Toaster />` mounts first — both
documented in the issue, neither pleasant.

## Fix

Two small, related changes:

1. **`src/state.ts` — replay queued toasts on subscribe.** When a new
   subscriber attaches, deliver any non-dismissed toasts already in
   `this.toasts`. Also guards the unsubscribe `splice` against
   `indexOf` returning `-1` (previously silently removed the last
   subscriber).

2. **`src/index.tsx` — drop the stale `[toasts]` dep on the Toaster's
   subscribe effect.** The setter is a functional update and doesn't
   need the value in deps. Without this, change 1 caused an infinite
   subscribe/replay/setState loop because every state change
   re-triggered the effect and re-replayed the queue. The per-toast
   auto-dismiss timer (which has `toast` in its deps) was cancelled and
   restarted on each iteration, so toasts appeared but never dismissed.

   Independently of change 1, the old `[toasts]` dep also created a
   race where any toast published between an unsubscribe and the
   matching re-subscribe could be lost.

## Test plan

- Added `/issue-723` route in `test/src/app/` that reproduces the
  original race: a sibling component fires `toast()` from its
  `useEffect` while rendered above `<Toaster />`.
- Added a Playwright regression test in `test/tests/basic.spec.ts`.
- Verified manually in production build (`pnpm --filter test build &&
  pnpm --filter test start`): toast appears and auto-dismisses after
  the default 4 s.
- Existing test suite still passes locally.