### PR TITLE
feat: add data-toast-id attribute to toast element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -272,6 +272,7 @@ const Toast = (props: ToastProps) => {
         toast?.classNames?.[toastType],
       )}
       data-sonner-toast=""
+      data-toast-id={String(toast.id)}
       data-rich-colors={toast.richColors ?? defaultRichColors}
       data-styled={!Boolean(toast.jsx || toast.unstyled || unstyled)}
       data-mounted={mounted}

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -344,6 +344,13 @@ export default function Home({ searchParams }: any) {
         Render Toast in Global Toaster
       </button>
       <button
+        data-testid="custom-id-toast"
+        className="button"
+        onClick={() => toast('Toast with custom id', { id: 'my-custom-id' })}
+      >
+        Toast with custom ID
+      </button>
+      <button
         data-testid="testid-toast-button"
         className="button"
         onClick={() => toast('Toast with test ID', { testId: 'my-test-toast' })}

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -331,6 +331,16 @@ test.describe('Basic functionality', () => {
     await expect(toast).not.toHaveAttribute('data-testid');
   });
 
+  test('toast renders with data-toast-id attribute', async ({ page }) => {
+    await page.getByTestId('default-button').click();
+    await expect(page.locator('[data-sonner-toast]')).toHaveAttribute('data-toast-id', /.+/);
+  });
+
+  test('toast renders correct data-toast-id when custom id is provided', async ({ page }) => {
+    await page.getByTestId('custom-id-toast').click();
+    await expect(page.locator('[data-sonner-toast][data-toast-id="my-custom-id"]')).toHaveCount(1);
+  });
+
   test('promise toast with testId maintains testId through state changes', async ({ page }) => {
     await page.getByTestId('testid-promise-toast-button').click();
     await expect(page.getByTestId('promise-test-toast')).toBeVisible();


### PR DESCRIPTION
## Summary

Adds a `data-toast-id` attribute to the rendered `<li>` toast element, exposing the toast ID in the DOM.

Closes #714

## Motivation

- **Targeted testing** in Playwright / Cypress / RTL — query toasts by their ID
- **Easier DOM querying** for automation or styling
- **Dynamic dismissal** — child elements can read the parent `data-toast-id` and call `toast.dismiss(id)` without needing the ID passed through props

## Example

```tsx
toast("Message", { id: "upload-success" });
```

Renders:

```html
<li data-sonner-toast data-toast-id="upload-success">...</li>
```

## Changes

- Added `data-toast-id={String(toast.id)}` to the `<li>` element in `Toast` component
- Added test cases verifying the attribute is present for both auto-generated and custom IDs
- Added test page button for testing custom ID toasts

## Testing

Added 2 new Playwright tests:
- Verifies `data-toast-id` is present on default toasts (auto-incremented numeric IDs)
- Verifies correct `data-toast-id` value when a custom string ID is provided