### PR TITLE
fix: respect swipeDirections for fast swipes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,6 +61,22 @@ function getDefaultSwipeDirections(position: string): Array<SwipeDirection> {
   return directions;
 }
 
+function isSwipeDirectionAllowed(
+  swipeAmount: number,
+  swipeAxis: 'x' | 'y' | null,
+  swipeDirections: Array<SwipeDirection>,
+) {
+  if (swipeAxis === 'x') {
+    return swipeAmount > 0 ? swipeDirections.includes('right') : swipeDirections.includes('left');
+  }
+
+  if (swipeAxis === 'y') {
+    return swipeAmount > 0 ? swipeDirections.includes('bottom') : swipeDirections.includes('top');
+  }
+
+  return false;
+}
+
 const Toast = (props: ToastProps) => {
   const {
     invert: ToasterInvert,
@@ -322,6 +338,7 @@ const Toast = (props: ToastProps) => {
         if (swipeOut || !dismissible) return;
 
         pointerStartRef.current = null;
+        const swipeDirections = props.swipeDirections ?? getDefaultSwipeDirections(position);
         const swipeAmountX = Number(
           toastRef.current?.style.getPropertyValue('--swipe-amount-x').replace('px', '') || 0,
         );
@@ -333,7 +350,10 @@ const Toast = (props: ToastProps) => {
         const swipeAmount = swipeDirection === 'x' ? swipeAmountX : swipeAmountY;
         const velocity = Math.abs(swipeAmount) / timeTaken;
 
-        if (Math.abs(swipeAmount) >= SWIPE_THRESHOLD || velocity > 0.11) {
+        if (
+          isSwipeDirectionAllowed(swipeAmount, swipeDirection, swipeDirections) &&
+          (Math.abs(swipeAmount) >= SWIPE_THRESHOLD || velocity > 0.11)
+        ) {
           setOffsetBeforeRemove(offset.current);
 
           toast.onDismiss?.(toast);

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Toaster, toast } from 'sonner';
+import { Toaster, toast, type SwipeDirection } from 'sonner';
 import { action } from '@/app/action';
 
 const promise = () => new Promise((resolve) => setTimeout(resolve, 2000));
@@ -12,6 +12,7 @@ export default function Home({ searchParams }: any) {
   const [theme, setTheme] = React.useState(searchParams.theme || 'light');
   const [isFinally, setIsFinally] = React.useState(false);
   const [showAriaLabels, setShowAriaLabels] = React.useState(false);
+  const swipeDirections = searchParams.swipeDirections?.split(',') as SwipeDirection[] | undefined;
 
   return (
     <>
@@ -369,6 +370,7 @@ export default function Home({ searchParams }: any) {
       <Toaster
         offset={32}
         position={searchParams.position || 'bottom-right'}
+        swipeDirections={swipeDirections}
         toastOptions={{
           actionButtonStyle: { backgroundColor: 'rgb(219, 239, 255)' },
           cancelButtonStyle: { backgroundColor: 'rgb(254, 226, 226)' },

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import React from 'react';
-import { Toaster, toast, type SwipeDirection } from 'sonner';
+import { Toaster, toast } from 'sonner';
 import { action } from '@/app/action';
 
 const promise = () => new Promise((resolve) => setTimeout(resolve, 2000));
+type SwipeDirection = 'top' | 'right' | 'bottom' | 'left';
 
 export default function Home({ searchParams }: any) {
   const [showAutoClose, setShowAutoClose] = React.useState(false);

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -118,6 +118,27 @@ test.describe('Basic functionality', () => {
     await expect(page.locator('[data-sonner-toast]')).toHaveCount(0);
   });
 
+  test('toast is not removed by a fast swipe in an excluded direction', async ({ page }) => {
+    await page.goto('/?position=top-center&swipeDirections=top,right');
+    await page.getByTestId('default-button').click();
+
+    const toast = page.locator('[data-sonner-toast]');
+    await toast.waitFor({ state: 'visible' });
+
+    const box = await toast.boundingBox();
+    if (!box) return;
+
+    const startX = box.x + box.width / 2;
+    const startY = box.y + box.height / 2;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX - 120, startY);
+    await page.mouse.up();
+
+    await expect(toast).toHaveCount(1);
+  });
+
   test('toast is not removed when hovered', async ({ page }) => {
     await page.getByTestId('default-button').click();
 


### PR DESCRIPTION
Fixes #762.

## Summary
- Check the final swipe direction in `onPointerUp` before dismissing a toast.
- Keep the existing dampened movement for excluded directions, but prevent velocity-only dismissals when that direction is not allowed by `swipeDirections`.
- Add a Playwright regression test for a fast left swipe when only `top` and `right` are allowed.

## Verification
- `pnpm build`
- `pnpm exec prettier --check src/index.tsx test/src/app/page.tsx test/tests/basic.spec.ts`
- `pnpm exec playwright test test/tests/basic.spec.ts -g "excluded direction" --project=chromium`

Note: `pnpm type-check` currently fails in this checkout because `@types/react` references `scheduler/tracing`, which is not resolved by the current dependency tree. This appears unrelated to this change.