### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/website/src/pages/getting-started.mdx
+++ b/website/src/pages/getting-started.mdx
@@ -8,7 +8,7 @@ Sonner is an opinionated toast component for React. You can read more about why 
 <Steps>
 ### Install
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun', 'deno']}>
   <Tab>
     ```bash
     pnpm i sonner
@@ -28,6 +28,11 @@ Sonner is an opinionated toast component for React. You can read more about why 
     <Tab>
     ```bash
     bun add sonner
+    ```
+  </Tab>
+    <Tab>
+    ```bash
+    deno add sonner
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The Install tabs list pnpm / npm / yarn / bun. Since Deno is a drop-in replacement for npm these days, this adds a Deno tab in parity:

```sh
deno add sonner
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
