### PR TITLE
feat: add logical start/end positioning with RTL-aware mobile placement

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -65,6 +65,14 @@ html[dir='rtl'],
   left: var(--offset-left);
 }
 
+[data-sonner-toaster][data-x-position='start'] {
+  inset-inline-start: var(--offset-left);
+}
+
+[data-sonner-toaster][data-x-position='end'] {
+  inset-inline-end: var(--offset-right);
+}
+
 [data-sonner-toaster][data-x-position='center'] {
   left: 50%;
   transform: translateX(-50%);
@@ -156,14 +164,14 @@ html[dir='rtl'],
   margin-right: var(--toast-icon-margin-end);
 }
 
-[data-sonner-toast][data-promise='true'] [data-icon] > svg {
+[data-sonner-toast][data-promise='true'] [data-icon]>svg {
   opacity: 0;
   transform: scale(0.8);
   transform-origin: center;
   animation: sonner-fade-in 300ms ease forwards;
 }
 
-[data-sonner-toast][data-styled='true'] [data-icon] > * {
+[data-sonner-toast][data-styled='true'] [data-icon]>* {
   flex-shrink: 0;
 }
 
@@ -296,7 +304,7 @@ html[dir='rtl'],
   height: var(--front-toast-height);
 }
 
-[data-sonner-toast] > * {
+[data-sonner-toast]>* {
   transition: opacity 400ms;
 }
 
@@ -308,7 +316,15 @@ html[dir='rtl'],
   left: 0;
 }
 
-[data-sonner-toast][data-expanded='false'][data-front='false'][data-styled='true'] > * {
+[data-sonner-toast][data-x-position='start'] {
+  inset-inline-start: 0;
+}
+
+[data-sonner-toast][data-x-position='end'] {
+  inset-inline-end: 0;
+}
+
+[data-sonner-toast][data-expanded='false'][data-front='false'][data-styled='true']>* {
   opacity: 0;
 }
 
@@ -348,7 +364,8 @@ html[dir='rtl'],
 }
 
 [data-sonner-toast][data-swiped='true'] {
-  -webkit-user-select: none; /* Safari 3+ */
+  -webkit-user-select: none;
+  /* Safari 3+ */
   user-select: none;
 }
 
@@ -675,6 +692,7 @@ html[dir='rtl'],
     opacity: 0;
     transform: scale(0.8);
   }
+
   100% {
     opacity: 1;
     transform: scale(1);
@@ -686,6 +704,7 @@ html[dir='rtl'],
     opacity: 1;
     transform: scale(1);
   }
+
   100% {
     opacity: 0;
     transform: scale(0.8);
@@ -696,14 +715,16 @@ html[dir='rtl'],
   0% {
     opacity: 1;
   }
+
   100% {
     opacity: 0.15;
   }
 }
 
 @media (prefers-reduced-motion) {
+
   [data-sonner-toast],
-  [data-sonner-toast] > *,
+  [data-sonner-toast]>*,
   .sonner-loading-bar {
     transition: none !important;
     animation: none !important;

--- a/src/styles.css
+++ b/src/styles.css
@@ -448,18 +448,41 @@ html[dir='rtl'],
     width: 100%;
   }
 
-  [data-sonner-toaster][dir='rtl'] {
-    left: calc(var(--mobile-offset-left) * -1);
-  }
-
-  [data-sonner-toaster] [data-sonner-toast] {
+  [data-sonner-toaster][data-x-position='center'] [data-sonner-toast] {
     left: 0;
     right: 0;
     width: calc(100% - var(--mobile-offset-left) * 2);
   }
 
+  [data-sonner-toaster][data-x-position='left'],
+  [data-sonner-toaster][data-x-position='right'],
+  [data-sonner-toaster][data-x-position='start'],
+  [data-sonner-toaster][data-x-position='end'] {
+    width: var(--width);
+  }
+
   [data-sonner-toaster][data-x-position='left'] {
     left: var(--mobile-offset-left);
+    right: unset;
+  }
+
+  [data-sonner-toaster][data-x-position='right'] {
+    right: var(--mobile-offset-right);
+    left: unset;
+  }
+
+  [data-sonner-toaster][data-x-position='start'] {
+    left: unset;
+    right: unset;
+    inset-inline-start: var(--mobile-offset-left);
+    inset-inline-end: unset;
+  }
+
+  [data-sonner-toaster][data-x-position='end'] {
+    left: unset;
+    right: unset;
+    inset-inline-end: var(--mobile-offset-right);
+    inset-inline-start: unset;
   }
 
   [data-sonner-toaster][data-y-position='bottom'] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,17 @@ export function isAction(action: Action | React.ReactNode): action is Action {
   return (action as Action).label !== undefined;
 }
 
-export type Position = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'top-center' | 'bottom-center';
+export type Position =
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'top-center'
+  | 'bottom-center'
+  | 'top-start'
+  | 'bottom-start'
+  | 'top-end'
+  | 'bottom-end';
 export interface HeightT {
   height: number;
   toastId: number | string;

--- a/website/src/components/Position/index.tsx
+++ b/website/src/components/Position/index.tsx
@@ -2,7 +2,18 @@ import { toast, useSonner } from 'sonner';
 import { CodeBlock } from '../CodeBlock';
 import React from 'react';
 
-const positions = ['top-left', 'top-center', 'top-right', 'bottom-left', 'bottom-center', 'bottom-right'] as const;
+const positions = [
+  'top-left',
+  'top-center',
+  'top-right',
+  'bottom-left',
+  'bottom-center',
+  'bottom-right',
+  'top-start',
+  'bottom-start',
+  'top-end',
+  'bottom-end',
+] as const;
 
 export type Position = (typeof positions)[number];
 

--- a/website/src/pages/toast.mdx
+++ b/website/src/pages/toast.mdx
@@ -148,6 +148,7 @@ function. It will not affect the positioning of other toasts.
 ```jsx
 // Available positions:
 // top-left, top-center, top-right, bottom-left, bottom-center, bottom-right
+// top-start, bottom-start, top-end, bottom-end
 toast('Hello World', {
   position: 'top-center',
 });

--- a/website/src/pages/toaster.mdx
+++ b/website/src/pages/toaster.mdx
@@ -38,6 +38,7 @@ Changes the place where all toasts will be rendered.
 ```jsx
 // Available positions:
 // top-left, top-center, top-right, bottom-left, bottom-center, bottom-right
+// top-start, bottom-start, top-end, bottom-end
 <Toaster position="top-center" />
 ```
 


### PR DESCRIPTION
# Context
Adds logical toaster positioning so start/end placement follows document direction, improving RTL support and making mobile alignment direction-aware.

## Changes
- Adds support for logical start/end positions in toaster APIs and docs.
- Updates mobile toaster CSS to anchor start/end using logical inset properties instead of physical-only left/right rules.
- Applies follow-up positioning refinements so RTL/LTR flipping behaves consistently across viewport sizes.

## Demo

<img width="1264" height="720" alt="chrome-capture-2026-06-23" src="https://github.com/user-attachments/assets/bd8d816e-d3f1-4176-b71b-74a620638acf" />
