### PR TITLE
fix: clean up dismissed toasts from internal array to prevent memory leak

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -89,13 +89,26 @@ class Observer {
     if (id) {
       this.dismissedToasts.add(id);
       requestAnimationFrame(() => this.subscribers.forEach((subscriber) => subscriber({ id, dismiss: true })));
+      // Clean up the toast from the internal array after the exit animation completes
+      setTimeout(() => {
+        this.toasts = this.toasts.filter((toast) => toast.id !== id);
+      }, 400);
     } else {
       this.toasts.forEach((toast) => {
         this.subscribers.forEach((subscriber) => subscriber({ id: toast.id, dismiss: true }));
       });
+      // Clean up all toasts from the internal array after the exit animation completes
+      setTimeout(() => {
+        this.toasts = [];
+      }, 400);
     }
 
     return id;
+  };
+
+  clearHistory = () => {
+    this.toasts = [];
+    this.dismissedToasts.clear();
   };
 
   message = (message: titleT | React.ReactNode, data?: ExternalToast) => {
@@ -294,6 +307,7 @@ export const toast = Object.assign(
     promise: ToastState.promise,
     dismiss: ToastState.dismiss,
     loading: ToastState.loading,
+    clearHistory: ToastState.clearHistory,
   },
   { getHistory, getToasts },
 );


### PR DESCRIPTION
Fixes #729 — memory leak in ToastState where dismissed toasts are never cleaned up.

Problem: The Observer class maintains a this.toasts array that accumulates every toast ever created. The dismiss method only adds IDs to this.dismissedToasts (a Set) but never removes the actual toast objects from this.toasts. Since each toast can contain JSX (React elements), this causes unbounded memory growth in long-running SPAs.

Fix:
1. Remove dismissed toasts from this.toasts after exit animation (400ms delay) so the array doesn't grow forever
2. Add clearHistory() method for manual cleanup, exposed via toast.clearHistory()

- [x] Type check passes
- [x] Build succeeds  
- [x] No breaking API changes