### PR TITLE
fix: respect swipeDirections for fast flick dismissals

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -333,16 +333,23 @@ const Toast = (props: ToastProps) => {
         const swipeAmount = swipeDirection === 'x' ? swipeAmountX : swipeAmountY;
         const velocity = Math.abs(swipeAmount) / timeTaken;
 
-        if (Math.abs(swipeAmount) >= SWIPE_THRESHOLD || velocity > 0.11) {
+        const swipeDirections = props.swipeDirections ?? getDefaultSwipeDirections(position);
+        const intendedSwipeDirection =
+          swipeDirection === 'x'
+            ? swipeAmountX > 0
+              ? 'right'
+              : 'left'
+            : swipeAmountY > 0
+            ? 'down'
+            : 'up';
+        const isAllowedSwipe = swipeDirections.includes(intendedSwipeDirection as SwipeDirection);
+
+        if (isAllowedSwipe && (Math.abs(swipeAmount) >= SWIPE_THRESHOLD || velocity > 0.11)) {
           setOffsetBeforeRemove(offset.current);
 
           toast.onDismiss?.(toast);
 
-          if (swipeDirection === 'x') {
-            setSwipeOutDirection(swipeAmountX > 0 ? 'right' : 'left');
-          } else {
-            setSwipeOutDirection(swipeAmountY > 0 ? 'down' : 'up');
-          }
+          setSwipeOutDirection(intendedSwipeDirection as 'left' | 'right' | 'up' | 'down');
 
           deleteToast();
           setSwipeOut(true);


### PR DESCRIPTION
Fixes #762

## Problem

When `swipeDirections` excludes a direction (e.g. `['top', 'right']` — no left), a fast flick leftward still dismisses the toast.

## Root Cause

`onPointerMove` correctly dampens disallowed swipes (caps at ~15–20px), but a 100ms flick at 15px produces `velocity ≈ 0.15`, which exceeds the `0.11` threshold in `onPointerUp`. The velocity check had no awareness of `swipeDirections`.

## Fix

In `onPointerUp`, compute the intended swipe direction from the sign of the displacement, then check it against `swipeDirections` before allowing dismissal. This mirrors the intent already enforced in `onPointerMove` for slower swipes.