### PR TITLE
fix: recalculate toast height when type or promise state changes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -181,7 +181,7 @@ const Toast = (props: ToastProps) => {
         return heights.map((height) => (height.toastId === toast.id ? { ...height, height: newHeight } : height));
       }
     });
-  }, [mounted, toast.title, toast.description, setHeights, toast.id, toast.jsx, toast.action, toast.cancel]);
+  }, [mounted, toast.title, toast.description, toast.type, toast.promise, setHeights, toast.id, toast.jsx, toast.action, toast.cancel]);
 
   const deleteToast = React.useCallback(() => {
     // Save the offset for the exit swipe animation


### PR DESCRIPTION
Fixes #719

## Problem

When a toast is replaced with another toast of the same ID but different height (e.g. shorter text → longer text, or promise toast loading → success), the layout doesn't recalculate. This causes visual clipping, overlap, or excessive space.

## Root Cause

The `useLayoutEffect` that measures and reports toast height was missing `toast.type` and `toast.promise` from its dependency array. When a promise toast transitions from loading to success, the icon changes from spinner to checkmark (potentially different height), but the effect never re-fires.

## Fix

Added `toast.type` and `toast.promise` to the dependency array so height measurement runs whenever the toast type or promise state changes.