### PR TITLE
fix: reset interacting state on pointercancel

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -844,6 +844,10 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
               setInteracting(true);
             }}
             onPointerUp={() => setInteracting(false)}
+            // The browser fires `pointercancel` instead of `pointerup` when it takes over the
+            // gesture (e.g. touch scrolling). Without this, `interacting` stays true forever and
+            // every toast stops auto-dismissing.
+            onPointerCancel={() => setInteracting(false)}
           >
             {filteredToasts
               .filter((toast) => (!toast.position && index === 0) || toast.position === position)

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -138,6 +138,20 @@ test.describe('Basic functionality', () => {
     await expect(page.locator('[data-sonner-toast]')).toHaveCount(1);
   });
 
+  test('toast is removed when the pointer gesture is cancelled', async ({ page }) => {
+    await page.getByTestId('default-button').click();
+
+    const toast = page.locator('[data-sonner-toast]');
+    await expect(toast).toBeVisible();
+
+    // The browser fires `pointercancel` instead of `pointerup` when it takes over the gesture,
+    // e.g. when touch scrolling starts. The toast should still dismiss itself afterwards.
+    await toast.dispatchEvent('pointerdown');
+    await toast.dispatchEvent('pointercancel');
+
+    await expect(toast).toHaveCount(0);
+  });
+
   test('toast is not removed if duration is set to infinity', async ({ page }) => {
     await page.getByTestId('infinity-toast').click();
 


### PR DESCRIPTION
## Problem

The `<ol>` in `Toaster` sets `interacting` on pointer down and only clears it on pointer up:

```jsx
onPointerDown={(event) => {
  const isNotDismissible =
    event.target instanceof HTMLElement && event.target.dataset.dismissible === 'false';

  if (isNotDismissible) return;
  setInteracting(true);
}}
onPointerUp={() => setInteracting(false)}
```

There is no `onPointerCancel`. When the browser takes over a gesture it fires `pointercancel` **instead of** `pointerup` — the `pointerup` event never arrives — so `interacting` stays `true`.

`interacting` gates the auto-close timer:

```js
if (expanded || interacting || isDocumentHidden) {
  pauseTimer();
} else {
  startTimer();
}
```

…and it lives on the `Toaster`, not on an individual toast. So one cancelled gesture stops **every** toast on the page from auto-dismissing for the rest of the page's lifetime — not just the one that was touched. To the user, toasts simply pile up and never go away.

Common `pointercancel` triggers on mobile:

- touch-scrolling starts and the browser claims the gesture
- the touch becomes a browser-level gesture (pull-to-refresh, back-swipe, long-press / text selection)
- the pointer is interrupted (app switch, incoming call)

We hit this in production on mobile and had to work around it by force-dismissing toasts from the app side.

## Fix

Reset the same state on cancel:

```jsx
onPointerCancel={() => setInteracting(false)}
```

## Test

Adds `toast is removed when the pointer gesture is cancelled` to `test/tests/basic.spec.ts`, which dispatches `pointerdown` followed by `pointercancel` and asserts the toast still auto-dismisses.

Verified locally against chromium:

- **without** the fix: fails — `expect(toast).toHaveCount(0)` gets `1`, the toast never dismisses
- **with** the fix: passes

Full suite: 36 passed, 1 failed. The one failure is `cancel button dismisses the custom toast with empty id`, which fails on the base commit too and is unrelated (it looks like the same thing #724 is addressing).

## Notes

- `onPointerLeave` may be worth considering separately, for the case where the pointer leaves the element while still down. I left it out to keep this focused.
