### PR TITLE
fix: remove matchMedia listener on theme change and unmount

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -716,28 +716,18 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
     if (typeof window === 'undefined') return;
     const darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
+    const handleThemeChange = ({ matches }: MediaQueryListEvent) => {
+      setActualTheme(matches ? 'dark' : 'light');
+    };
+
     try {
       // Chrome & Firefox
-      darkMediaQuery.addEventListener('change', ({ matches }) => {
-        if (matches) {
-          setActualTheme('dark');
-        } else {
-          setActualTheme('light');
-        }
-      });
+      darkMediaQuery.addEventListener('change', handleThemeChange);
+      return () => darkMediaQuery.removeEventListener('change', handleThemeChange);
     } catch (error) {
       // Safari < 14
-      darkMediaQuery.addListener(({ matches }) => {
-        try {
-          if (matches) {
-            setActualTheme('dark');
-          } else {
-            setActualTheme('light');
-          }
-        } catch (e) {
-          console.error(e);
-        }
-      });
+      darkMediaQuery.addListener(handleThemeChange);
+      return () => darkMediaQuery.removeListener(handleThemeChange);
     }
   }, [theme]);
 


### PR DESCRIPTION
`src/index.tsx`'s `theme="system"` effect attaches a `prefers-color-scheme` listener but never returns a cleanup function.

Its dependency array is `[theme]`, so each theme change builds a fresh `MediaQueryList` via `window.matchMedia()` and attaches another listener, while every earlier one stays alive. Nothing is released on unmount either. An app binding the prop to a live toggle — `<Toaster theme={theme} />` — accumulates one leaked closure over `setActualTheme` per toggle, for the lifetime of the page.

Modelling the effect's attach/cleanup contract over five theme changes plus an unmount:

| | listeners still attached |
|---|---|
| before | 5 |
| after | 0 |

The fix hoists the handler so it has a stable identity and returns a cleanup that removes it, mirroring what #711 did for the visibility listener in `hooks.tsx`. Both branches are covered — `removeEventListener` for Chrome/Firefox, `removeListener` for the Safari <14 fallback.

One deliberate simplification worth flagging: the old Safari branch wrapped its `setActualTheme` calls in an inner `try/catch` that logged to `console.error`. Sharing one handler between the branches drops that. `setActualTheme` is a `useState` setter and won't throw, and the outer `try/catch` still guards the `addListener` call itself — but happy to restore it if you'd rather keep the belt and braces.

Fixes #782