### PR TITLE
fix: reset swipe and interaction state on pointercancel

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -368,6 +368,18 @@ const Toast = (props: ToastProps) => {
         setSwiping(false);
         setSwipeDirection(null);
       }}
+      onPointerCancel={() => {
+        // The browser fires this instead of pointerup when it takes the gesture
+        // over, so the swipe has to be unwound here too.
+        if (swipeOut || !dismissible) return;
+
+        pointerStartRef.current = null;
+        toastRef.current?.style.setProperty('--swipe-amount-x', '0px');
+        toastRef.current?.style.setProperty('--swipe-amount-y', '0px');
+        setIsSwiped(false);
+        setSwiping(false);
+        setSwipeDirection(null);
+      }}
       onPointerMove={(event) => {
         if (!pointerStartRef.current || !dismissible) return;
 
@@ -855,6 +867,7 @@ const Toaster = React.forwardRef<HTMLElement, ToasterProps>(function Toaster(pro
               setInteracting(true);
             }}
             onPointerUp={() => setInteracting(false)}
+            onPointerCancel={() => setInteracting(false)}
           >
             {filteredToasts
               .filter((toast) => (!toast.position && index === 0) || toast.position === position)

--- a/test/tests/basic.spec.ts
+++ b/test/tests/basic.spec.ts
@@ -407,6 +407,28 @@ test.describe('Basic functionality', () => {
     await expect(toast).toHaveCount(1);
   });
 
+  test('a cancelled swipe returns the toast to rest', async ({ page }) => {
+    await page.goto('/?position=top-center');
+    await page.getByTestId('default-button').click();
+
+    const toast = page.locator('[data-sonner-toast]').first();
+    const box = await toast.boundingBox();
+    if (!box) throw new Error('Toast not rendered');
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2 + 40, box.y + box.height / 2, { steps: 5 });
+
+    await expect(toast).toHaveAttribute('data-swiping', 'true');
+
+    await toast.dispatchEvent('pointercancel', { bubbles: true });
+
+    await expect(toast).toHaveAttribute('data-swiping', 'false');
+    await expect
+      .poll(() => toast.evaluate((el: HTMLElement) => el.style.getPropertyValue('--swipe-amount-x')))
+      .toBe('0px');
+  });
+
   test('toast() clears the loading state of a toast with the same id', async ({ page }) => {
     await page.getByTestId('loading-toast-fixed-id').click();
     const toast = page.locator('[data-sonner-toast]');


### PR DESCRIPTION
Fixes #779.

### Problem

The browser fires `pointercancel` **instead of** `pointerup` when it takes a pointer over — an OS-level gesture, another surface stealing the touch, some multi-touch conflicts. Nothing in `src/index.tsx` listened for it, so both pieces of state a swipe sets were left behind.

**On the toast**, `isSwiping`, `swipeDirection`, `pointerStartRef` and the `--swipe-amount-x/y` custom properties all stayed as they were, leaving the toast parked mid-swipe until the next full down/up cycle. That is the reported bug.

**On the toaster**, there is a second instance of the same gap that the issue does not mention, and it is the worse of the two. `onPointerDown` sets `interacting`, and only `onPointerUp` clears it:

```tsx
onPointerDown={...setInteracting(true)}
onPointerUp={() => setInteracting(false)}
```

`interacting` gates the dismiss timer:

```tsx
if (expanded || interacting || isDocumentHidden) {
  pauseTimer();
}
```

So a cancelled gesture left every toast paused and they stopped auto-dismissing entirely, not just visually stuck.

### Fix

`onPointerCancel` in both places. On the toast it unwinds the swipe without dismissing — a cancelled gesture is not a swipe-out. On the toaster it clears `interacting` so the timer resumes.

### Testing

One Playwright test: swipe part way, fire `pointercancel`, assert `data-swiping` goes back to `false` and `--swipe-amount-x` returns to `0px`. It fails on `main` and passes with the change.

**I could not write an honest test for the toaster half**, and would rather say so than ship one that looks like coverage. Playwright cannot release its own mouse without emitting `pointerup`, and `pointerup` clears `interacting` anyway — so any test I wrote passed with and without the fix. Going without `pointerup` keeps pointer capture active, so `mouseleave` never fires and `expanded` stays `true`, which pauses the timer on its own and hides the effect. I confirmed both of those by instrumenting the DOM rather than assuming:

```
swiping: "false"   <- toast-level fix working
expanded: "true"   <- what actually blocks the timer in the test
```

Happy to split the toaster change into its own PR if you would rather keep this one to what the test covers.